### PR TITLE
cbor: support field omission on optional map entries

### DIFF
--- a/src/cbor/derive/src/lib.rs
+++ b/src/cbor/derive/src/lib.rs
@@ -97,6 +97,7 @@ fn derive_encode_array(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<T
 }
 
 /// Generates map-mode `Encode` impl: fields encoded as key-value pairs, sorted by key bytes.
+/// Option<T> fields are omitted when None (the key-value pair is not encoded).
 fn derive_encode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
     let cbor_crate = quote! { darkbio_crypto::cbor };
 
@@ -117,31 +118,72 @@ fn derive_encode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
         ka.cmp(&kb)
     });
 
-    let len = sorted.len();
+    // Check if any field is optional (affects whether map size is static or dynamic)
+    let has_optional = sorted.iter().any(|f| extract_option_inner(&f.kind).is_some());
 
-    // Generate code to encode each key-value pair in sorted order
+    // Generate code to count and encode fields. Optional fields are only included
+    // when they are Some, so the map header count must be computed at runtime.
+    let count_fields: Vec<_> = sorted
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            if extract_option_inner(&f.kind).is_some() {
+                quote! { if self.#ident.is_some() { count += 1; } }
+            } else {
+                quote! { count += 1; }
+            }
+        })
+        .collect();
+
     let encode_fields: Vec<_> = sorted
         .iter()
         .map(|f| {
             let ident = &f.ident;
             let key = f.key.unwrap();
-            quote! {
-                enc.encode_int(#key);
-                enc.extend(&self.#ident.encode_cbor());
+            if extract_option_inner(&f.kind).is_some() {
+                quote! {
+                    if let Some(ref v) = self.#ident {
+                        enc.encode_int(#key);
+                        enc.extend(&v.encode_cbor());
+                    }
+                }
+            } else {
+                quote! {
+                    enc.encode_int(#key);
+                    enc.extend(&self.#ident.encode_cbor());
+                }
             }
         })
         .collect();
 
-    Ok(quote! {
-        impl #cbor_crate::Encode for #name {
-            fn encode_cbor(&self) -> Vec<u8> {
-                let mut enc = #cbor_crate::Encoder::new();
-                enc.encode_map_header(#len);
-                #(#encode_fields)*
-                enc.finish()
+    // If there are no optional fields, use a static map header size to avoid
+    // generating unnecessary runtime counting code.
+    if has_optional {
+        Ok(quote! {
+            impl #cbor_crate::Encode for #name {
+                fn encode_cbor(&self) -> Vec<u8> {
+                    let mut enc = #cbor_crate::Encoder::new();
+                    let mut count: usize = 0;
+                    #(#count_fields)*
+                    enc.encode_map_header(count);
+                    #(#encode_fields)*
+                    enc.finish()
+                }
             }
-        }
-    })
+        })
+    } else {
+        let len = sorted.len();
+        Ok(quote! {
+            impl #cbor_crate::Encode for #name {
+                fn encode_cbor(&self) -> Vec<u8> {
+                    let mut enc = #cbor_crate::Encoder::new();
+                    enc.encode_map_header(#len);
+                    #(#encode_fields)*
+                    enc.finish()
+                }
+            }
+        })
+    }
 }
 
 /// Generates the `Decode` trait implementation for a struct.
@@ -194,6 +236,7 @@ fn derive_decode_array(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<T
 }
 
 /// Generates map-mode `Decode` impl: fields decoded as key-value pairs, validating key order.
+/// Option<T> fields tolerate missing keys by defaulting to None.
 fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
     let cbor_crate = quote! { darkbio_crypto::cbor };
 
@@ -216,41 +259,107 @@ fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
 
     let len = sorted.len();
 
-    // Generate code to decode each key-value pair, validating key order
+    // Check if any field is optional (affects decoding strategy)
+    let has_optional = sorted.iter().any(|f| extract_option_inner(&f.kind).is_some());
+
+    // Use original field order for struct construction (not sorted order)
+    let construct_fields: Vec<_> = fields.iter().map(|f| &f.ident).collect();
+
+    // If there are no optional fields, use the simple fixed-count decoder to
+    // avoid generating unnecessary runtime tracking code.
+    if !has_optional {
+        let decode_fields: Vec<_> = sorted
+            .iter()
+            .map(|f| {
+                let ident = &f.ident;
+                let ty = &f.kind;
+                let key = f.key.unwrap();
+                quote! {
+                    let key = dec.decode_int()?;
+                    if key != #key {
+                        return Err(#cbor_crate::Error::InvalidMapKeyOrder(key, #key));
+                    }
+                    let #ident = <#ty as #cbor_crate::Decode>::decode_cbor_notrail(dec)?;
+                }
+            })
+            .collect();
+
+        return Ok(quote! {
+            impl #cbor_crate::Decode for #name {
+                fn decode_cbor(data: &[u8]) -> Result<Self, #cbor_crate::Error> {
+                    let mut dec = #cbor_crate::Decoder::new(data);
+                    let result = Self::decode_cbor_notrail(&mut dec)?;
+                    dec.finish()?;
+                    Ok(result)
+                }
+
+                fn decode_cbor_notrail(dec: &mut #cbor_crate::Decoder) -> Result<Self, #cbor_crate::Error> {
+                    let len = dec.decode_map_header()?;
+                    if len != #len as u64 {
+                        return Err(#cbor_crate::Error::UnexpectedItemCount(len, #len));
+                    }
+                    #(#decode_fields)*
+                    Ok(Self { #(#construct_fields),* })
+                }
+            }
+        });
+    }
+
+    // Generate code to decode each field, walking expected keys in sorted order
+    // against actual map entries. Optional fields with missing keys default to None.
     let decode_fields: Vec<_> = sorted
         .iter()
         .map(|f| {
             let ident = &f.ident;
-            let ty = &f.kind;
             let key = f.key.unwrap();
-            quote! {
-                let key = dec.decode_int()?;
-                if key != #key {
-                    return Err(#cbor_crate::Error::InvalidMapKeyOrder(key, #key));
+            if let Some(inner_ty) = extract_option_inner(&f.kind) {
+                // Optional: peek at next key, decode if matching, else None
+                quote! {
+                    let #ident = if remaining > 0 && dec.peek_int()? == #key {
+                        dec.decode_int()?;
+                        remaining -= 1;
+                        Some(<#inner_ty as #cbor_crate::Decode>::decode_cbor_notrail(dec)?)
+                    } else {
+                        None
+                    };
                 }
-                let #ident = <#ty as #cbor_crate::Decode>::decode_cbor_notrail(dec)?;
+            } else {
+                // Required: must be present with correct key
+                let ty = &f.kind;
+                quote! {
+                    if remaining == 0 {
+                        return Err(#cbor_crate::Error::InvalidMapKeyOrder(0, #key));
+                    }
+                    let key = dec.decode_int()?;
+                    if key != #key {
+                        return Err(#cbor_crate::Error::InvalidMapKeyOrder(key, #key));
+                    }
+                    remaining -= 1;
+                    let #ident = <#ty as #cbor_crate::Decode>::decode_cbor_notrail(dec)?;
+                }
             }
         })
         .collect();
-
-    // Use original field order for struct construction (not sorted order)
-    let construct_fields: Vec<_> = fields.iter().map(|f| &f.ident).collect();
 
     Ok(quote! {
         impl #cbor_crate::Decode for #name {
             fn decode_cbor(data: &[u8]) -> Result<Self, #cbor_crate::Error> {
                 let mut dec = #cbor_crate::Decoder::new(data);
                 let result = Self::decode_cbor_notrail(&mut dec)?;
-                dec.finish()?; // Ensure no trailing data
+                dec.finish()?;
                 Ok(result)
             }
 
             fn decode_cbor_notrail(dec: &mut #cbor_crate::Decoder) -> Result<Self, #cbor_crate::Error> {
-                let len = dec.decode_map_header()?;
-                if len != #len as u64 {
-                    return Err(#cbor_crate::Error::UnexpectedItemCount(len, #len));
+                let map_len = dec.decode_map_header()?;
+                if map_len > #len as u64 {
+                    return Err(#cbor_crate::Error::UnexpectedItemCount(map_len, #len));
                 }
+                let mut remaining = map_len;
                 #(#decode_fields)*
+                if remaining != 0 {
+                    return Err(#cbor_crate::Error::UnexpectedItemCount(map_len, (map_len - remaining) as usize));
+                }
                 Ok(Self { #(#construct_fields),* })
             }
         }
@@ -320,6 +429,23 @@ fn parse_fields(input: &DeriveInput) -> syn::Result<Vec<FieldInfo>> {
         result.push(FieldInfo { ident, kind, key });
     }
     Ok(result)
+}
+
+/// Checks if a type is `Option<T>` and returns the inner type `T`.
+fn extract_option_inner(ty: &syn::Type) -> Option<&syn::Type> {
+    if let syn::Type::Path(type_path) = ty {
+        let segment = type_path.path.segments.last()?;
+        if segment.ident == "Option" {
+            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                if args.args.len() == 1 {
+                    if let syn::GenericArgument::Type(inner) = args.args.first()? {
+                        return Some(inner);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Parses an integer expression, handling both positive literals and negation.

--- a/src/cbor/derive/src/lib.rs
+++ b/src/cbor/derive/src/lib.rs
@@ -119,7 +119,9 @@ fn derive_encode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
     });
 
     // Check if any field is optional (affects whether map size is static or dynamic)
-    let has_optional = sorted.iter().any(|f| extract_option_inner(&f.kind).is_some());
+    let has_optional = sorted
+        .iter()
+        .any(|f| extract_option_inner(&f.kind).is_some());
 
     // Generate code to count and encode fields. Optional fields are only included
     // when they are Some, so the map header count must be computed at runtime.
@@ -260,7 +262,9 @@ fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
     let len = sorted.len();
 
     // Check if any field is optional (affects decoding strategy)
-    let has_optional = sorted.iter().any(|f| extract_option_inner(&f.kind).is_some());
+    let has_optional = sorted
+        .iter()
+        .any(|f| extract_option_inner(&f.kind).is_some());
 
     // Use original field order for struct construction (not sorted order)
     let construct_fields: Vec<_> = fields.iter().map(|f| &f.ident).collect();
@@ -451,19 +455,17 @@ fn parse_fields(input: &DeriveInput) -> syn::Result<Vec<FieldInfo>> {
 fn extract_option_inner(ty: &syn::Type) -> Option<&syn::Type> {
     if let syn::Type::Path(type_path) = ty {
         let segment = type_path.path.segments.last()?;
-        if segment.ident == "Option" {
-            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                if args.args.len() == 1 {
-                    if let syn::GenericArgument::Type(inner) = args.args.first()? {
-                        // Option<Option<T>> is NOT omittable — it's a non-omittable
-                        // nullable field. See extract_nullable_inner.
-                        if is_option_type(inner) {
-                            return None;
-                        }
-                        return Some(inner);
-                    }
-                }
+        if segment.ident == "Option"
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+            && args.args.len() == 1
+            && let syn::GenericArgument::Type(inner) = args.args.first()?
+        {
+            // Option<Option<T>> is NOT omittable — it's a non-omittable
+            // nullable field. See extract_nullable_inner.
+            if is_option_type(inner) {
+                return None;
             }
+            return Some(inner);
         }
     }
     None
@@ -476,16 +478,13 @@ fn extract_option_inner(ty: &syn::Type) -> Option<&syn::Type> {
 fn extract_nullable_inner(ty: &syn::Type) -> Option<&syn::Type> {
     if let syn::Type::Path(type_path) = ty {
         let segment = type_path.path.segments.last()?;
-        if segment.ident == "Option" {
-            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                if args.args.len() == 1 {
-                    if let syn::GenericArgument::Type(inner) = args.args.first()? {
-                        if is_option_type(inner) {
-                            return Some(inner);
-                        }
-                    }
-                }
-            }
+        if segment.ident == "Option"
+            && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+            && args.args.len() == 1
+            && let syn::GenericArgument::Type(inner) = args.args.first()?
+            && is_option_type(inner)
+        {
+            return Some(inner);
         }
     }
     None
@@ -493,10 +492,10 @@ fn extract_nullable_inner(ty: &syn::Type) -> Option<&syn::Type> {
 
 /// Returns true if the type's last path segment is `Option`.
 fn is_option_type(ty: &syn::Type) -> bool {
-    if let syn::Type::Path(type_path) = ty {
-        if let Some(segment) = type_path.path.segments.last() {
-            return segment.ident == "Option";
-        }
+    if let syn::Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident == "Option";
     }
     false
 }

--- a/src/cbor/mod.rs
+++ b/src/cbor/mod.rs
@@ -1711,9 +1711,9 @@ mod tests {
     fn test_map_optional_decoding() {
         // Decode a map with required + nullable (null value), optionals absent
         let decoded = decode::<TestMapOptional>(&vec![
-            0xa2,             // map with 2 entries
+            0xa2, // map with 2 entries
             0x01, 0x18, 0x2a, // 1: 42
-            0x03, 0xf6,       // 3: null
+            0x03, 0xf6, // 3: null
         ])
         .unwrap();
         assert_eq!(decoded.required, 42);
@@ -1723,10 +1723,10 @@ mod tests {
 
         // Decode a map with required + nullable + first optional
         let decoded = decode::<TestMapOptional>(&vec![
-            0xa3,                         // map with 3 entries
-            0x01, 0x00,                   // 1: 0
-            0x02, 0x62, 0x68, 0x69,       // 2: "hi"
-            0x03, 0xf6,                   // 3: null
+            0xa3, // map with 3 entries
+            0x01, 0x00, // 1: 0
+            0x02, 0x62, 0x68, 0x69, // 2: "hi"
+            0x03, 0xf6, // 3: null
         ])
         .unwrap();
         assert_eq!(decoded.required, 0);
@@ -1736,10 +1736,10 @@ mod tests {
 
         // Decode a map with required + nullable + second optional (key -1)
         let decoded = decode::<TestMapOptional>(&vec![
-            0xa3,                   // map with 3 entries
-            0x01, 0x05,             // 1: 5
-            0x03, 0xf6,             // 3: null
-            0x20, 0x41, 0xab,       // -1: h'ab'
+            0xa3, // map with 3 entries
+            0x01, 0x05, // 1: 5
+            0x03, 0xf6, // 3: null
+            0x20, 0x41, 0xab, // -1: h'ab'
         ])
         .unwrap();
         assert_eq!(decoded.required, 5);
@@ -1749,7 +1749,7 @@ mod tests {
 
         // Decode with nullable absent must fail (it's required)
         let result = decode::<TestMapOptional>(&vec![
-            0xa1,             // map with 1 entry
+            0xa1, // map with 1 entry
             0x01, 0x18, 0x2a, // 1: 42 (key 3 missing)
         ]);
         assert!(result.is_err());
@@ -1778,7 +1778,7 @@ mod tests {
 
         // Nullable field missing (key 3 must always be present)
         let result = decode::<TestMapOptional>(&vec![
-            0xa1,             // map with 1 entry
+            0xa1, // map with 1 entry
             0x01, 0x18, 0x2a, // 1: 42 (key 3 missing)
         ]);
         assert!(result.is_err());


### PR DESCRIPTION
This PR adds support for omitted map keys in CBOR encoding. Whilst previously optional was meant to be only used in arrays to encode as null, now they can also be used in maps, with a slightly different semantic.

Care needs to be taken to keep support for non-omitted null fields, since we can't anticipate what different protocols spec. This is still supported via the Option<Option<>> type.

Another important caveat, the 3 way field: omitted, present but null, present but value. This is forbidden as it's borderline meaningless. So whilst a cute pedantic case, it should not be supported.