### PR TITLE
cbor: omit null map entries for Option::None

### DIFF
--- a/src/cbor/derive/src/lib.rs
+++ b/src/cbor/derive/src/lib.rs
@@ -117,7 +117,7 @@ fn derive_encode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
         ka.cmp(&kb)
     });
 
-    let len = sorted.len();
+    let has_optional = sorted.iter().any(|f| f.optional);
 
     // Generate code to encode each key-value pair in sorted order
     let encode_fields: Vec<_> = sorted
@@ -125,23 +125,62 @@ fn derive_encode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
         .map(|f| {
             let ident = &f.ident;
             let key = f.key.unwrap();
-            quote! {
-                enc.encode_int(#key);
-                enc.extend(&self.#ident.encode_cbor());
+            if f.optional {
+                quote! {
+                    if let Some(ref val) = self.#ident {
+                        enc.encode_int(#key);
+                        enc.extend(&val.encode_cbor());
+                    }
+                }
+            } else {
+                quote! {
+                    enc.encode_int(#key);
+                    enc.extend(&self.#ident.encode_cbor());
+                }
             }
         })
         .collect();
 
-    Ok(quote! {
-        impl #cbor_crate::Encode for #name {
-            fn encode_cbor(&self) -> Vec<u8> {
-                let mut enc = #cbor_crate::Encoder::new();
-                enc.encode_map_header(#len);
-                #(#encode_fields)*
-                enc.finish()
+    if has_optional {
+        // Count optional fields to compute length at runtime
+        let count_fields: Vec<_> = sorted
+            .iter()
+            .map(|f| {
+                let ident = &f.ident;
+                if f.optional {
+                    quote! { if self.#ident.is_some() { len += 1; } }
+                } else {
+                    quote! { len += 1; }
+                }
+            })
+            .collect();
+
+        Ok(quote! {
+            impl #cbor_crate::Encode for #name {
+                fn encode_cbor(&self) -> Vec<u8> {
+                    let mut len: usize = 0;
+                    #(#count_fields)*
+
+                    let mut enc = #cbor_crate::Encoder::new();
+                    enc.encode_map_header(len);
+                    #(#encode_fields)*
+                    enc.finish()
+                }
             }
-        }
-    })
+        })
+    } else {
+        let len = sorted.len();
+        Ok(quote! {
+            impl #cbor_crate::Encode for #name {
+                fn encode_cbor(&self) -> Vec<u8> {
+                    let mut enc = #cbor_crate::Encoder::new();
+                    enc.encode_map_header(#len);
+                    #(#encode_fields)*
+                    enc.finish()
+                }
+            }
+        })
+    }
 }
 
 /// Generates the `Decode` trait implementation for a struct.
@@ -195,8 +234,6 @@ fn derive_decode_array(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<T
 
 /// Generates map-mode `Decode` impl: fields decoded as key-value pairs, validating key order.
 fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<TokenStream2> {
-    let cbor_crate = quote! { darkbio_crypto::cbor };
-
     // Validate all fields have keys
     for field in fields {
         if field.key.is_none() {
@@ -214,9 +251,27 @@ fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
         ka.cmp(&kb)
     });
 
+    let has_optional = sorted.iter().any(|f| f.optional);
+
+    // Use original field order for struct construction (not sorted order)
+    let construct_fields: Vec<_> = fields.iter().map(|f| &f.ident).collect();
+
+    if has_optional {
+        derive_decode_map_with_optionals(name, &sorted, &construct_fields)
+    } else {
+        derive_decode_map_required_only(name, &sorted, &construct_fields)
+    }
+}
+
+/// Generates map-mode `Decode` impl when all fields are required (no Option fields).
+fn derive_decode_map_required_only(
+    name: &syn::Ident,
+    sorted: &[&FieldInfo],
+    construct_fields: &[&syn::Ident],
+) -> syn::Result<TokenStream2> {
+    let cbor_crate = quote! { darkbio_crypto::cbor };
     let len = sorted.len();
 
-    // Generate code to decode each key-value pair, validating key order
     let decode_fields: Vec<_> = sorted
         .iter()
         .map(|f| {
@@ -233,15 +288,12 @@ fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
         })
         .collect();
 
-    // Use original field order for struct construction (not sorted order)
-    let construct_fields: Vec<_> = fields.iter().map(|f| &f.ident).collect();
-
     Ok(quote! {
         impl #cbor_crate::Decode for #name {
             fn decode_cbor(data: &[u8]) -> Result<Self, #cbor_crate::Error> {
                 let mut dec = #cbor_crate::Decoder::new(data);
                 let result = Self::decode_cbor_notrail(&mut dec)?;
-                dec.finish()?; // Ensure no trailing data
+                dec.finish()?;
                 Ok(result)
             }
 
@@ -251,6 +303,109 @@ fn derive_decode_map(name: &syn::Ident, fields: &[FieldInfo]) -> syn::Result<Tok
                     return Err(#cbor_crate::Error::UnexpectedItemCount(len, #len));
                 }
                 #(#decode_fields)*
+                Ok(Self { #(#construct_fields),* })
+            }
+        }
+    })
+}
+
+/// Generates map-mode `Decode` impl when some fields are Option (may be omitted).
+fn derive_decode_map_with_optionals(
+    name: &syn::Ident,
+    sorted: &[&FieldInfo],
+    construct_fields: &[&syn::Ident],
+) -> syn::Result<TokenStream2> {
+    let cbor_crate = quote! { darkbio_crypto::cbor };
+
+    let num_required = sorted.iter().filter(|f| !f.optional).count();
+    let num_total = sorted.len();
+
+    // Initialize all field variables (Option fields default to None)
+    let init_fields: Vec<_> = sorted
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            if f.optional {
+                quote! { let mut #ident = None; }
+            } else {
+                let ty = &f.kind;
+                quote! { let mut #ident: Option<#ty> = None; }
+            }
+        })
+        .collect();
+
+    // Build match arms: for each key, decode the corresponding field
+    let match_arms: Vec<_> = sorted
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            let key = f.key.unwrap();
+            let inner_ty = &f.inner_ty;
+            quote! {
+                #key => {
+                    #ident = Some(<#inner_ty as #cbor_crate::Decode>::decode_cbor_notrail(dec)?);
+                }
+            }
+        })
+        .collect();
+
+    // Build the sorted key list for order validation
+    let sorted_keys: Vec<_> = sorted.iter().map(|f| f.key.unwrap()).collect();
+
+    // Unwrap required fields (non-Option), checking they were present
+    let unwrap_fields: Vec<_> = sorted
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            if f.optional {
+                // Already the right type (Option<T>), no unwrap needed
+                quote! {}
+            } else {
+                let key = f.key.unwrap();
+                quote! {
+                    let #ident = #ident.ok_or(#cbor_crate::Error::MissingMapKey(#key))?;
+                }
+            }
+        })
+        .collect();
+
+    Ok(quote! {
+        impl #cbor_crate::Decode for #name {
+            fn decode_cbor(data: &[u8]) -> Result<Self, #cbor_crate::Error> {
+                let mut dec = #cbor_crate::Decoder::new(data);
+                let result = Self::decode_cbor_notrail(&mut dec)?;
+                dec.finish()?;
+                Ok(result)
+            }
+
+            fn decode_cbor_notrail(dec: &mut #cbor_crate::Decoder) -> Result<Self, #cbor_crate::Error> {
+                let map_len = dec.decode_map_header()? as usize;
+                if map_len < #num_required || map_len > #num_total {
+                    return Err(#cbor_crate::Error::UnexpectedItemCount(map_len as u64, #num_required));
+                }
+                #(#init_fields)*
+
+                // Track key ordering using the expected key sequence
+                const SORTED_KEYS: &[i64] = &[#(#sorted_keys),*];
+                let mut key_idx = 0usize;
+
+                for _ in 0..map_len {
+                    let key = dec.decode_int()?;
+
+                    // Advance past optional keys that were skipped
+                    while key_idx < SORTED_KEYS.len() && SORTED_KEYS[key_idx] != key {
+                        key_idx += 1;
+                    }
+                    if key_idx >= SORTED_KEYS.len() {
+                        return Err(#cbor_crate::Error::InvalidMapKeyOrder(key, *SORTED_KEYS.last().unwrap()));
+                    }
+                    match key {
+                        #(#match_arms)*
+                        _ => return Err(#cbor_crate::Error::InvalidMapKeyOrder(key, SORTED_KEYS[key_idx])),
+                    }
+                    key_idx += 1;
+                }
+                #(#unwrap_fields)*
                 Ok(Self { #(#construct_fields),* })
             }
         }
@@ -280,7 +435,9 @@ fn want_array(input: &DeriveInput) -> bool {
 struct FieldInfo {
     ident: syn::Ident,
     kind: syn::Type,
-    key: Option<i64>, // CBOR map key from #[cbor(key = N)], None for array-mode
+    key: Option<i64>,    // CBOR map key from #[cbor(key = N)], None for array-mode
+    optional: bool,      // Whether the field type is Option<T>
+    inner_ty: syn::Type, // Inner type (T for Option<T>, same as kind otherwise)
 }
 
 /// Extracts field metadata from a struct, including names, types, and CBOR keys.
@@ -317,7 +474,14 @@ fn parse_fields(input: &DeriveInput) -> syn::Result<Vec<FieldInfo>> {
                 })?;
             }
         }
-        result.push(FieldInfo { ident, kind, key });
+        let (optional, inner_ty) = extract_option_inner(&kind);
+        result.push(FieldInfo {
+            ident,
+            kind,
+            key,
+            optional,
+            inner_ty,
+        });
     }
     Ok(result)
 }
@@ -343,4 +507,20 @@ fn parse_key(expr: &Expr) -> syn::Result<i64> {
         }
         _ => Err(syn::Error::new_spanned(expr, "expected integer literal")),
     }
+}
+
+/// Returns (true, inner_type) if `ty` is `Option<T>`, otherwise (false, ty.clone()).
+fn extract_option_inner(ty: &syn::Type) -> (bool, syn::Type) {
+    if let syn::Type::Path(type_path) = ty {
+        if let Some(seg) = type_path.path.segments.last() {
+            if seg.ident == "Option" {
+                if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        return (true, inner.clone());
+                    }
+                }
+            }
+        }
+    }
+    (false, ty.clone())
 }


### PR DESCRIPTION
Claude Opus 4.6 via AmpCode. 2-3 min, 74,000 tokens.

> Our current CBOR encoder encodes Option<> None as cbor::Null. We only ever used it in array positionals so that's fine. But in maps, this doesn't make sense, we should just omit the field. Lets plan this out , let me confirm, then we can implement it