### PR TITLE
cbor: implement support for type embeddings, surface encode errors

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,10 +3,22 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -34,19 +46,19 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "darkbio-crypto"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "darkbio-crypto-cbor-derive",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
- "getrandom 0.4.0-rc.0",
+ "getrandom 0.4.1",
  "thiserror",
  "web-time",
 ]
 
 [[package]]
 name = "darkbio-crypto-cbor-derive"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -62,10 +74,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
@@ -96,17 +120,63 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.0-rc.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -129,6 +199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,10 +221,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -179,6 +277,54 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "shlex"
@@ -224,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +386,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -284,6 +445,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,3 +493,91 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/fuzz/fuzz_targets/cbor.rs
+++ b/fuzz/fuzz_targets/cbor.rs
@@ -43,8 +43,9 @@ macro_rules! roundtrip {
     ($data:expr, $( $typ:ty ),+ $(,)?) => {
         $(
             if let Ok(decoded) = decode::<$typ>($data) {
-                let encoded = encode(&decoded);
-                let decoded2 = decode::<$typ>(&encoded)
+            let encoded = encode(&decoded)
+                .expect(concat!("Failed to encode decoded data for ", stringify!($typ)));
+            let decoded2 = decode::<$typ>(&encoded)
                     .expect(concat!("Failed to decode re-encoded data for ", stringify!($typ)));
                 assert_eq!(decoded, decoded2, "Roundtrip failed for type: {}", stringify!($typ));
             }

--- a/fuzz/fuzz_targets/cbor.rs
+++ b/fuzz/fuzz_targets/cbor.rs
@@ -43,9 +43,9 @@ macro_rules! roundtrip {
     ($data:expr, $( $typ:ty ),+ $(,)?) => {
         $(
             if let Ok(decoded) = decode::<$typ>($data) {
-            let encoded = encode(&decoded)
-                .expect(concat!("Failed to encode decoded data for ", stringify!($typ)));
-            let decoded2 = decode::<$typ>(&encoded)
+                let encoded = encode(&decoded)
+                    .expect(concat!("Failed to encode decoded data for ", stringify!($typ)));
+                let decoded2 = decode::<$typ>(&encoded)
                     .expect(concat!("Failed to decode re-encoded data for ", stringify!($typ)));
                 assert_eq!(decoded, decoded2, "Roundtrip failed for type: {}", stringify!($typ));
             }

--- a/src/cbor/mod.rs
+++ b/src/cbor/mod.rs
@@ -780,11 +780,7 @@ impl<T: Encode> Encode for Option<T> {
     fn encode_cbor(&self) -> Result<Vec<u8>, Error> {
         match self {
             Some(value) => value.encode_cbor(),
-            None => {
-                let mut buf = Vec::new();
-                buf.push(MAJOR_SIMPLE << 5 | SIMPLE_NULL);
-                Ok(buf)
-            }
+            None => Ok(vec![MAJOR_SIMPLE << 5 | SIMPLE_NULL]),
         }
     }
 
@@ -867,8 +863,7 @@ impl MapEncodeBuffer {
             .all(|w| cbor_key_cmp(w[0].0, w[1].0) == Ordering::Less);
 
         if !ordered {
-            self.entries
-                .sort_unstable_by(|a, b| cbor_key_cmp(a.0, b.0));
+            self.entries.sort_unstable_by(|a, b| cbor_key_cmp(a.0, b.0));
         }
         // Verify no duplicates after sorting
         for w in self.entries.windows(2) {

--- a/src/cose/mod.rs
+++ b/src/cose/mod.rs
@@ -13,7 +13,7 @@ mod types;
 
 pub use types::{
     CoseEncrypt0, CoseSign1, CritHeader, EmptyHeader, EncProtectedHeader, EncStructure,
-    EncapKeyHeader, SigProtectedHeader, SigStructure, HEADER_TIMESTAMP,
+    EncapKeyHeader, HEADER_TIMESTAMP, SigProtectedHeader, SigStructure,
 };
 
 // Use an indirect time package that mostly defers to sts::time on most platforms,

--- a/src/cose/types.rs
+++ b/src/cose/types.rs
@@ -123,14 +123,13 @@ pub struct SigStructure<'a> {
 }
 
 impl crate::cbor::Encode for SigStructure<'_> {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        let mut encoder = crate::cbor::Encoder::new();
-        encoder.encode_array_header(4);
-        encoder.encode_text(self.context);
-        encoder.encode_bytes(self.protected);
-        encoder.encode_bytes(self.external_aad);
-        encoder.encode_bytes(self.payload);
-        Ok(encoder.finish())
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        crate::cbor::encode_array_header_to(buf, 4);
+        self.context.encode_cbor_to(buf)?;
+        self.protected.encode_cbor_to(buf)?;
+        self.external_aad.encode_cbor_to(buf)?;
+        self.payload.encode_cbor_to(buf)?;
+        Ok(())
     }
 }
 
@@ -151,12 +150,11 @@ pub struct EncStructure<'a> {
 }
 
 impl crate::cbor::Encode for EncStructure<'_> {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        let mut encoder = crate::cbor::Encoder::new();
-        encoder.encode_array_header(3);
-        encoder.encode_text(self.context);
-        encoder.encode_bytes(self.protected);
-        encoder.encode_bytes(self.external_aad);
-        Ok(encoder.finish())
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        crate::cbor::encode_array_header_to(buf, 3);
+        self.context.encode_cbor_to(buf)?;
+        self.protected.encode_cbor_to(buf)?;
+        self.external_aad.encode_cbor_to(buf)?;
+        Ok(())
     }
 }

--- a/src/cose/types.rs
+++ b/src/cose/types.rs
@@ -123,14 +123,14 @@ pub struct SigStructure<'a> {
 }
 
 impl crate::cbor::Encode for SigStructure<'_> {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         let mut encoder = crate::cbor::Encoder::new();
         encoder.encode_array_header(4);
         encoder.encode_text(self.context);
         encoder.encode_bytes(self.protected);
         encoder.encode_bytes(self.external_aad);
         encoder.encode_bytes(self.payload);
-        encoder.finish()
+        Ok(encoder.finish())
     }
 }
 
@@ -151,12 +151,12 @@ pub struct EncStructure<'a> {
 }
 
 impl crate::cbor::Encode for EncStructure<'_> {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         let mut encoder = crate::cbor::Encoder::new();
         encoder.encode_array_header(3);
         encoder.encode_text(self.context);
         encoder.encode_bytes(self.protected);
         encoder.encode_bytes(self.external_aad);
-        encoder.finish()
+        Ok(encoder.finish())
     }
 }

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -215,8 +215,8 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -270,8 +270,8 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -325,8 +325,8 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -215,7 +215,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -270,7 +270,7 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -325,7 +325,7 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }

--- a/src/mldsa/mod.rs
+++ b/src/mldsa/mod.rs
@@ -302,7 +302,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -357,7 +357,7 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -412,7 +412,7 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }

--- a/src/mldsa/mod.rs
+++ b/src/mldsa/mod.rs
@@ -302,8 +302,8 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -357,8 +357,8 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -412,8 +412,8 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 

--- a/src/rsa/mod.rs
+++ b/src/rsa/mod.rs
@@ -319,7 +319,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -374,7 +374,7 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -429,7 +429,7 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }

--- a/src/rsa/mod.rs
+++ b/src/rsa/mod.rs
@@ -319,8 +319,8 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -374,8 +374,8 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -429,8 +429,8 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 

--- a/src/xdsa/mod.rs
+++ b/src/xdsa/mod.rs
@@ -330,8 +330,8 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -430,8 +430,8 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -485,8 +485,8 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 

--- a/src/xdsa/mod.rs
+++ b/src/xdsa/mod.rs
@@ -330,7 +330,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -430,7 +430,7 @@ impl<'de> Deserialize<'de> for Signature {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Signature {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -485,7 +485,7 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }

--- a/src/xhpke/mod.rs
+++ b/src/xhpke/mod.rs
@@ -326,7 +326,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }
@@ -381,7 +381,7 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Vec<u8> {
+    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
         self.to_bytes().encode_cbor()
     }
 }

--- a/src/xhpke/mod.rs
+++ b/src/xhpke/mod.rs
@@ -326,8 +326,8 @@ impl<'de> Deserialize<'de> for PublicKey {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for PublicKey {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 
@@ -381,8 +381,8 @@ impl<'de> Deserialize<'de> for Fingerprint {
 
 #[cfg(feature = "cbor")]
 impl crate::cbor::Encode for Fingerprint {
-    fn encode_cbor(&self) -> Result<Vec<u8>, crate::cbor::Error> {
-        self.to_bytes().encode_cbor()
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), crate::cbor::Error> {
+        self.to_bytes().encode_cbor_to(buf)
     }
 }
 


### PR DESCRIPTION
This is a fairly heavy rework of the cbor derive macro to introduce an `embed` command, that can flatten an embedded struct field into the parent when cbor encoding. The purpose is to simulate Go's struct embeds and allow assembling larger flat CBOR types from smaller components. This will come in handy for CWT and family.

This PR switched cbor::encode to return a Result instead of only the encoded type. Unfortunately this is a necessity for the type embeddings as Rust's derive macros don't have access to remote types that are embedded, so we can't detect duplicate keys compile time. There's also a massive diff across the entire library because of this.