### PR TITLE
cwt, cbor: implement CWT claims and add a few EAT ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = []
 argon2 = ["dep:argon2"]
 cbor = ["dep:thiserror", "dep:darkbio-crypto-cbor-derive"]
 cose = ["cbor", "xdsa", "xhpke"]
+cwt = ["cose"]
 eddsa = [
     "pem",
     "dep:der",

--- a/src/cbor/mod.rs
+++ b/src/cbor/mod.rs
@@ -465,6 +465,12 @@ impl<'a> Decoder<'a> {
         self.clone().decode_int()
     }
 
+    // peek_uint returns the next unsigned integer value without consuming it.
+    // Unlike peek_int, this only matches CBOR major type 0 (positive integers).
+    pub fn peek_uint(&self) -> Result<u64, Error> {
+        self.clone().decode_uint()
+    }
+
     // decode_header extracts the major type for the next field and the integer
     // value embedded as the additional info.
     fn decode_header(&mut self) -> Result<(u8, u64), Error> {

--- a/src/cwt/claims/eat.rs
+++ b/src/cwt/claims/eat.rs
@@ -1,0 +1,716 @@
+// crypto-rs: cryptography primitives and wrappers
+// Copyright 2026 Dark Bio AG. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! EAT (Entity Attestation Token) claims.
+//!
+//! <https://datatracker.ietf.org/doc/html/rfc9711>
+
+use crate::cbor::{
+    self, Cbor, Decode, Encode, MapDecode, MapEncode, MapEncodeBuffer, MapEntryAccess,
+};
+
+/// UEID is a globally unique device identifier such as a serial number
+/// or IMEI (key 256). The value is an opaque byte string including a
+/// type prefix byte per RFC 9711 Section 4.2.1.
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct Ueid {
+    #[cbor(key = 256)]
+    pub ueid: Vec<u8>,
+}
+
+/// OEMID identifies the hardware manufacturer (key 258, RFC 9711 Section 4.2.3).
+/// The OEM can be identified by a random ID, an IEEE OUI, or an IANA PEN.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Oemid {
+    value: OemidValue,
+}
+
+impl Oemid {
+    /// Creates an OEMID from a 16-byte random manufacturer identifier.
+    pub fn new_random(id: [u8; 16]) -> Self {
+        Self {
+            value: OemidValue::Random(id),
+        }
+    }
+
+    /// Creates an OEMID from a 3-byte IEEE OUI/MA-L.
+    pub fn new_ieee(id: [u8; 3]) -> Self {
+        Self {
+            value: OemidValue::Ieee(id),
+        }
+    }
+
+    /// Creates an OEMID from an IANA Private Enterprise Number.
+    pub fn new_pen(pen: u64) -> Self {
+        Self {
+            value: OemidValue::Pen(pen),
+        }
+    }
+
+    /// Returns the 16-byte random OEM ID, or None if this is not a random OEM ID.
+    pub fn random(&self) -> Option<[u8; 16]> {
+        match self.value {
+            OemidValue::Random(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Returns the 3-byte IEEE OUI/MA-L, or None if this is not an IEEE OEM ID.
+    pub fn ieee(&self) -> Option<[u8; 3]> {
+        match self.value {
+            OemidValue::Ieee(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Returns the IANA Private Enterprise Number, or None if this is not a PEN OEM ID.
+    pub fn pen(&self) -> Option<u64> {
+        match self.value {
+            OemidValue::Pen(pen) => Some(pen),
+            _ => None,
+        }
+    }
+}
+
+/// Internal representation of the three OEM ID formats.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum OemidValue {
+    Random([u8; 16]),
+    Ieee([u8; 3]),
+    Pen(u64),
+}
+
+impl Encode for OemidValue {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        match self {
+            OemidValue::Random(id) => id.as_slice().encode_cbor_to(buf),
+            OemidValue::Ieee(id) => id.as_slice().encode_cbor_to(buf),
+            OemidValue::Pen(pen) => pen.encode_cbor_to(buf),
+        }
+    }
+}
+
+impl Decode for OemidValue {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        // Peek at major type to determine format: uint -> PEN, bytes -> Random or IEEE
+        if dec.peek_uint().is_ok() {
+            let pen = dec.decode_uint()?;
+            return Ok(OemidValue::Pen(pen));
+        }
+        // Not an integer, must be bytes
+        let bytes = dec.decode_bytes()?;
+        match bytes.len() {
+            3 => {
+                let mut id = [0u8; 3];
+                id.copy_from_slice(&bytes);
+                Ok(OemidValue::Ieee(id))
+            }
+            16 => {
+                let mut id = [0u8; 16];
+                id.copy_from_slice(&bytes);
+                Ok(OemidValue::Random(id))
+            }
+            n => Err(cbor::Error::DecodeFailed(format!(
+                "oemid: unexpected bstr length {n}"
+            ))),
+        }
+    }
+}
+
+impl Encode for Oemid {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        let mut enc = MapEncodeBuffer::new(1);
+        <Self as MapEncode>::encode_map(self, &mut enc)?;
+        enc.finish_to(buf)
+    }
+}
+
+impl Decode for Oemid {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        let entries = cbor::decode_map_entries_slices_notrail(dec)?;
+        let mut remaining = cbor::MapEntries::new(entries);
+        let value = <Self as MapDecode>::decode_map(&mut remaining)?;
+        if !remaining.is_empty() {
+            let unknown: Vec<i64> = remaining.remaining_keys();
+            return Err(cbor::Error::DecodeFailed(format!(
+                "unknown CBOR map keys: {unknown:?}"
+            )));
+        }
+        Ok(value)
+    }
+}
+
+impl MapEncode for Oemid {
+    fn encode_map(&self, enc: &mut MapEncodeBuffer) -> Result<(), cbor::Error> {
+        enc.push(258, &self.value)
+    }
+}
+
+impl MapDecode for Oemid {
+    fn cbor_map_keys() -> &'static [i64] {
+        &[258]
+    }
+
+    fn decode_map<'a, E: MapEntryAccess<'a>>(entries: &mut E) -> Result<Self, cbor::Error> {
+        let raw = entries
+            .take(258)
+            .ok_or(cbor::Error::DecodeFailed("missing required key 258".into()))?;
+        let value = OemidValue::decode_cbor(raw)?;
+        Ok(Self { value })
+    }
+}
+
+/// HwModel is the product or board model identifier (key 259).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct HwModel {
+    #[cbor(key = 259)]
+    pub hw_model: Vec<u8>,
+}
+
+/// HwVersion is the hardware revision identifier (key 260).
+/// CBOR-encodes as a 1-element array per RFC 9711 Section 4.2.5:
+/// `[version: tstr]`. The optional scheme is not supported.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HwVersion {
+    version: String,
+}
+
+impl HwVersion {
+    /// Creates an HwVersion with the given version string.
+    pub fn new(version: String) -> Self {
+        Self { version }
+    }
+
+    /// Returns the hardware version string.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+/// Internal 1-element array for HW/SW version encoding.
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+#[cbor(array)]
+struct VersionArray {
+    version: String,
+}
+
+impl Encode for HwVersion {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        let mut enc = MapEncodeBuffer::new(1);
+        <Self as MapEncode>::encode_map(self, &mut enc)?;
+        enc.finish_to(buf)
+    }
+}
+
+impl Decode for HwVersion {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        let entries = cbor::decode_map_entries_slices_notrail(dec)?;
+        let mut remaining = cbor::MapEntries::new(entries);
+        let value = <Self as MapDecode>::decode_map(&mut remaining)?;
+        if !remaining.is_empty() {
+            let unknown: Vec<i64> = remaining.remaining_keys();
+            return Err(cbor::Error::DecodeFailed(format!(
+                "unknown CBOR map keys: {unknown:?}"
+            )));
+        }
+        Ok(value)
+    }
+}
+
+impl MapEncode for HwVersion {
+    fn encode_map(&self, enc: &mut MapEncodeBuffer) -> Result<(), cbor::Error> {
+        let arr = VersionArray {
+            version: self.version.clone(),
+        };
+        enc.push(260, &arr)
+    }
+}
+
+impl MapDecode for HwVersion {
+    fn cbor_map_keys() -> &'static [i64] {
+        &[260]
+    }
+
+    fn decode_map<'a, E: MapEntryAccess<'a>>(entries: &mut E) -> Result<Self, cbor::Error> {
+        let raw = entries
+            .take(260)
+            .ok_or(cbor::Error::DecodeFailed("missing required key 260".into()))?;
+        let arr = VersionArray::decode_cbor(raw)?;
+        Ok(Self {
+            version: arr.version,
+        })
+    }
+}
+
+/// Uptime is the number of seconds since the last boot (key 261).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct Uptime {
+    #[cbor(key = 261)]
+    pub uptime: u64,
+}
+
+/// OemBoot indicates whether the boot chain is OEM-authorized,
+/// i.e. secure boot passed (key 262).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct OemBoot {
+    #[cbor(key = 262)]
+    pub oem_boot: bool,
+}
+
+/// DebugState represents the debug port state per RFC 9711 Section 4.2.9.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u64)]
+pub enum DebugState {
+    /// Debug is currently enabled.
+    Enabled = 0,
+    /// Debug is currently disabled.
+    Disabled = 1,
+    /// Debug was disabled at boot and has not been enabled since.
+    DisabledSinceBoot = 2,
+    /// Debug is disabled and cannot be re-enabled.
+    DisabledPermanently = 3,
+    /// All debug, including DMA-based, is permanently disabled.
+    DisabledFullyPermanently = 4,
+}
+
+impl Encode for DebugState {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        (*self as u64).encode_cbor_to(buf)
+    }
+}
+
+impl Decode for DebugState {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        let value = dec.decode_uint()?;
+        match value {
+            0 => Ok(DebugState::Enabled),
+            1 => Ok(DebugState::Disabled),
+            2 => Ok(DebugState::DisabledSinceBoot),
+            3 => Ok(DebugState::DisabledPermanently),
+            4 => Ok(DebugState::DisabledFullyPermanently),
+            _ => Err(cbor::Error::DecodeFailed(format!(
+                "invalid debug state: {value}"
+            ))),
+        }
+    }
+}
+
+/// DebugStatus is the debug port state (key 263).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct DebugStatus {
+    #[cbor(key = 263)]
+    pub debug_status: DebugState,
+}
+
+/// BootCount is the number of times the device has booted,
+/// as a monotonic counter (key 267).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct BootCount {
+    #[cbor(key = 267)]
+    pub boot_count: u64,
+}
+
+/// BootSeed is a random value unique to the current boot cycle (key 268).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct BootSeed {
+    #[cbor(key = 268)]
+    pub boot_seed: Vec<u8>,
+}
+
+/// SwName is the name of the firmware or software running on the
+/// device (key 270).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct SwName {
+    #[cbor(key = 270)]
+    pub sw_name: String,
+}
+
+/// SwVersion is the software version identifier (key 271).
+/// CBOR-encodes as a 1-element array per RFC 9711 Section 4.2.7:
+/// `[version: tstr]`. The optional scheme is not supported.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SwVersion {
+    version: String,
+}
+
+impl SwVersion {
+    /// Creates a SwVersion with the given version string.
+    pub fn new(version: String) -> Self {
+        Self { version }
+    }
+
+    /// Returns the software version string.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+impl Encode for SwVersion {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        let mut enc = MapEncodeBuffer::new(1);
+        <Self as MapEncode>::encode_map(self, &mut enc)?;
+        enc.finish_to(buf)
+    }
+}
+
+impl Decode for SwVersion {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        let entries = cbor::decode_map_entries_slices_notrail(dec)?;
+        let mut remaining = cbor::MapEntries::new(entries);
+        let value = <Self as MapDecode>::decode_map(&mut remaining)?;
+        if !remaining.is_empty() {
+            let unknown: Vec<i64> = remaining.remaining_keys();
+            return Err(cbor::Error::DecodeFailed(format!(
+                "unknown CBOR map keys: {unknown:?}"
+            )));
+        }
+        Ok(value)
+    }
+}
+
+impl MapEncode for SwVersion {
+    fn encode_map(&self, enc: &mut MapEncodeBuffer) -> Result<(), cbor::Error> {
+        let arr = VersionArray {
+            version: self.version.clone(),
+        };
+        enc.push(271, &arr)
+    }
+}
+
+impl MapDecode for SwVersion {
+    fn cbor_map_keys() -> &'static [i64] {
+        &[271]
+    }
+
+    fn decode_map<'a, E: MapEntryAccess<'a>>(entries: &mut E) -> Result<Self, cbor::Error> {
+        let raw = entries
+            .take(271)
+            .ok_or(cbor::Error::DecodeFailed("missing required key 271".into()))?;
+        let arr = VersionArray::decode_cbor(raw)?;
+        Ok(Self {
+            version: arr.version,
+        })
+    }
+}
+
+/// Use represents the token's intended purpose per RFC 9711 Section 4.3.3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u64)]
+pub enum Use {
+    /// General-purpose attestation.
+    Generic = 1,
+    /// Attestation for service registration.
+    Registration = 2,
+    /// Attestation prior to key/config provisioning.
+    Provisioning = 3,
+    /// Attestation for certificate signing requests.
+    CertIssuance = 4,
+    /// Attestation accompanying a proof-of-possession.
+    ProofOfPossession = 5,
+}
+
+impl Encode for Use {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        (*self as u64).encode_cbor_to(buf)
+    }
+}
+
+impl Decode for Use {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        let value = dec.decode_uint()?;
+        match value {
+            1 => Ok(Use::Generic),
+            2 => Ok(Use::Registration),
+            3 => Ok(Use::Provisioning),
+            4 => Ok(Use::CertIssuance),
+            5 => Ok(Use::ProofOfPossession),
+            _ => Err(cbor::Error::DecodeFailed(format!(
+                "invalid intended use: {value}"
+            ))),
+        }
+    }
+}
+
+/// IntendedUse is the token's purpose (key 275).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct IntendedUse {
+    #[cbor(key = 275)]
+    pub intended_use: Use,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies round-trip encoding of a random OEM ID.
+    #[test]
+    fn test_oemid_random() {
+        let id: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            oemid: Oemid,
+        }
+        let orig = Token {
+            oemid: Oemid::new_random(id),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.oemid.random(), Some(id));
+    }
+
+    /// Verifies round-trip encoding of an IEEE OEM ID.
+    #[test]
+    fn test_oemid_ieee() {
+        let id: [u8; 3] = [0xAC, 0xDE, 0x48];
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            oemid: Oemid,
+        }
+        let orig = Token {
+            oemid: Oemid::new_ieee(id),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.oemid.ieee(), Some(id));
+    }
+
+    /// Verifies round-trip encoding of a PEN OEM ID.
+    #[test]
+    fn test_oemid_pen() {
+        let pen: u64 = 76543;
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            oemid: Oemid,
+        }
+        let orig = Token {
+            oemid: Oemid::new_pen(pen),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.oemid.pen(), Some(pen));
+    }
+
+    /// Verifies that accessors return None for mismatched types.
+    #[test]
+    fn test_oemid_wrong_accessor() {
+        let o = Oemid::new_pen(42);
+        assert_eq!(o.random(), None);
+        assert_eq!(o.ieee(), None);
+    }
+
+    /// Verifies round-trip encoding of a hardware version.
+    #[test]
+    fn test_hw_version() {
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            hw: HwVersion,
+        }
+        let orig = Token {
+            hw: HwVersion::new("1.2.3".into()),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.hw.version(), "1.2.3");
+    }
+
+    /// Verifies round-trip encoding of a software version.
+    #[test]
+    fn test_sw_version() {
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            sw: SwVersion,
+        }
+        let orig = Token {
+            sw: SwVersion::new("4.5.6".into()),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.sw.version(), "4.5.6");
+    }
+
+    /// Verifies round-trip encoding of the simple EAT claims.
+    #[test]
+    fn test_simple_claims() {
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            ueid: Ueid,
+            #[cbor(embed)]
+            hw_model: HwModel,
+            #[cbor(embed)]
+            uptime: Uptime,
+            #[cbor(embed)]
+            oem_boot: OemBoot,
+            #[cbor(embed)]
+            debug_status: DebugStatus,
+            #[cbor(embed)]
+            boot_count: BootCount,
+            #[cbor(embed)]
+            boot_seed: BootSeed,
+            #[cbor(embed)]
+            sw_name: SwName,
+            #[cbor(embed)]
+            intended_use: IntendedUse,
+        }
+        let orig = Token {
+            ueid: Ueid {
+                ueid: vec![0x01, 0x02, 0x03],
+            },
+            hw_model: HwModel {
+                hw_model: b"board-v2".to_vec(),
+            },
+            uptime: Uptime { uptime: 3600 },
+            oem_boot: OemBoot { oem_boot: true },
+            debug_status: DebugStatus {
+                debug_status: DebugState::DisabledPermanently,
+            },
+            boot_count: BootCount { boot_count: 42 },
+            boot_seed: BootSeed {
+                boot_seed: vec![0xDE, 0xAD],
+            },
+            sw_name: SwName {
+                sw_name: "firmware-v3".into(),
+            },
+            intended_use: IntendedUse {
+                intended_use: Use::CertIssuance,
+            },
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.ueid.ueid, vec![0x01, 0x02, 0x03]);
+        assert_eq!(got.hw_model.hw_model, b"board-v2");
+        assert_eq!(got.uptime.uptime, 3600);
+        assert!(got.oem_boot.oem_boot);
+        assert_eq!(
+            got.debug_status.debug_status,
+            DebugState::DisabledPermanently
+        );
+        assert_eq!(got.boot_count.boot_count, 42);
+        assert_eq!(got.boot_seed.boot_seed, vec![0xDE, 0xAD]);
+        assert_eq!(got.sw_name.sw_name, "firmware-v3");
+        assert_eq!(got.intended_use.intended_use, Use::CertIssuance);
+    }
+
+    /// Tests that a byte string of invalid length is rejected for OEMID.
+    #[test]
+    fn test_oemid_invalid_length() {
+        let mut enc = cbor::Encoder::new();
+        enc.encode_map_header(1);
+        enc.encode_int(258);
+        enc.encode_bytes(&[1, 2, 3, 4, 5]); // 5 bytes: neither 3 nor 16
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            oemid: Oemid,
+        }
+        assert!(Token::decode_cbor(&enc.finish()).is_err());
+    }
+
+    /// Tests that a non-bstr/uint CBOR type is rejected for OEMID.
+    #[test]
+    fn test_oemid_invalid_type() {
+        let mut enc = cbor::Encoder::new();
+        enc.encode_map_header(1);
+        enc.encode_int(258);
+        enc.encode_text("not-bytes");
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            oemid: Oemid,
+        }
+        assert!(Token::decode_cbor(&enc.finish()).is_err());
+    }
+
+    /// Tests that an out-of-range debug state is rejected.
+    #[test]
+    fn test_debug_state_invalid() {
+        let mut enc = cbor::Encoder::new();
+        enc.encode_map_header(1);
+        enc.encode_int(263);
+        enc.encode_uint(99); // not in 0..4
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            debug: DebugStatus,
+        }
+        assert!(Token::decode_cbor(&enc.finish()).is_err());
+    }
+
+    /// Tests that an out-of-range intended use is rejected.
+    #[test]
+    fn test_use_invalid() {
+        let mut enc = cbor::Encoder::new();
+        enc.encode_map_header(1);
+        enc.encode_int(275);
+        enc.encode_uint(0); // not in 1..5
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            intended_use: IntendedUse,
+        }
+        assert!(Token::decode_cbor(&enc.finish()).is_err());
+    }
+}

--- a/src/cwt/claims/mod.rs
+++ b/src/cwt/claims/mod.rs
@@ -7,27 +7,6 @@
 //! Standard CWT claim types.
 //!
 //! <https://datatracker.ietf.org/doc/html/rfc8392>
-//!
-//! Each claim is a single-field struct that can be composed into application-specific
-//! token types via `#[cbor(embed)]`.
-//!
-//! # Example
-//!
-//! ```ignore
-//! #[derive(Cbor)]
-//! struct MyClaims {
-//!     #[cbor(embed)]
-//!     sub: claims::Subject,
-//!     #[cbor(embed)]
-//!     nbf: claims::NotBefore,
-//!     #[cbor(embed)]
-//!     exp: Option<claims::Expiration>,
-//!     #[cbor(embed)]
-//!     cnf: claims::Confirm<xdsa::PublicKey>,
-//!     #[cbor(embed)]
-//!     ueid: claims::eat::Ueid,
-//! }
-//! ```
 
 pub mod eat;
 
@@ -37,10 +16,6 @@ use crate::cbor::{
 use crate::cose;
 use crate::xdsa;
 use crate::xhpke;
-
-// ---------------------------------------------------------------------------
-// RFC 8392 — CWT claims (keys 1–7)
-// ---------------------------------------------------------------------------
 
 /// Issuer identifies the principal that issued the token (key 1).
 #[derive(Clone, Debug, PartialEq, Eq, Cbor)]
@@ -90,10 +65,6 @@ pub struct TokenId {
     #[cbor(key = 7)]
     pub cti: Vec<u8>,
 }
-
-// ---------------------------------------------------------------------------
-// RFC 8747 — Confirm<T> (key 8)
-// ---------------------------------------------------------------------------
 
 /// Sealed trait implementation module. The supertrait lives in a private module
 /// so external crates cannot implement `ConfirmKey`.

--- a/src/cwt/claims/mod.rs
+++ b/src/cwt/claims/mod.rs
@@ -1,0 +1,368 @@
+// crypto-rs: cryptography primitives and wrappers
+// Copyright 2026 Dark Bio AG. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! Standard CWT claim types.
+//!
+//! <https://datatracker.ietf.org/doc/html/rfc8392>
+//!
+//! Each claim is a single-field struct that can be composed into application-specific
+//! token types via `#[cbor(embed)]`.
+//!
+//! # Example
+//!
+//! ```ignore
+//! #[derive(Cbor)]
+//! struct MyClaims {
+//!     #[cbor(embed)]
+//!     sub: claims::Subject,
+//!     #[cbor(embed)]
+//!     nbf: claims::NotBefore,
+//!     #[cbor(embed)]
+//!     exp: Option<claims::Expiration>,
+//!     #[cbor(embed)]
+//!     cnf: claims::Confirm<xdsa::PublicKey>,
+//!     #[cbor(embed)]
+//!     ueid: claims::eat::Ueid,
+//! }
+//! ```
+
+pub mod eat;
+
+use crate::cbor::{
+    self, Cbor, Decode, Encode, MapDecode, MapEncode, MapEncodeBuffer, MapEntryAccess,
+};
+use crate::cose;
+use crate::xdsa;
+use crate::xhpke;
+
+// ---------------------------------------------------------------------------
+// RFC 8392 — CWT claims (keys 1–7)
+// ---------------------------------------------------------------------------
+
+/// Issuer identifies the principal that issued the token (key 1).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct Issuer {
+    #[cbor(key = 1)]
+    pub iss: String,
+}
+
+/// Subject identifies the principal that is the subject of the token (key 2).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct Subject {
+    #[cbor(key = 2)]
+    pub sub: String,
+}
+
+/// Audience identifies the recipients the token is intended for (key 3).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct Audience {
+    #[cbor(key = 3)]
+    pub aud: String,
+}
+
+/// Expiration is the time on or after which the token must not be accepted (key 4).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct Expiration {
+    #[cbor(key = 4)]
+    pub exp: u64,
+}
+
+/// NotBefore is the time before which the token must not be accepted (key 5).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct NotBefore {
+    #[cbor(key = 5)]
+    pub nbf: u64,
+}
+
+/// IssuedAt is the time at which the token was issued (key 6).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct IssuedAt {
+    #[cbor(key = 6)]
+    pub iat: u64,
+}
+
+/// TokenID is a unique identifier for the token (key 7).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+pub struct TokenId {
+    #[cbor(key = 7)]
+    pub cti: Vec<u8>,
+}
+
+// ---------------------------------------------------------------------------
+// RFC 8747 — Confirm<T> (key 8)
+// ---------------------------------------------------------------------------
+
+/// Sealed trait implementation module. The supertrait lives in a private module
+/// so external crates cannot implement `ConfirmKey`.
+mod sealed {
+    use crate::cbor;
+
+    pub trait ConfirmKeySealed {
+        const ALGORITHM: i64;
+        fn to_confirm_bytes(&self) -> Vec<u8>;
+        fn from_confirm_bytes(bytes: &[u8]) -> Result<Self, cbor::Error>
+        where
+            Self: Sized;
+    }
+}
+
+/// Marker trait for key types usable with [`Confirm`].
+///
+/// Implemented for [`xdsa::PublicKey`] and [`xhpke::PublicKey`].
+pub trait ConfirmKey: sealed::ConfirmKeySealed + Clone + std::fmt::Debug {}
+
+impl sealed::ConfirmKeySealed for xdsa::PublicKey {
+    const ALGORITHM: i64 = cose::ALGORITHM_ID_XDSA;
+
+    fn to_confirm_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+
+    fn from_confirm_bytes(bytes: &[u8]) -> Result<Self, cbor::Error> {
+        let arr: [u8; xdsa::PUBLIC_KEY_SIZE] = bytes.try_into().map_err(|_| {
+            cbor::Error::DecodeFailed(format!(
+                "cnf: unexpected key size {}, want {}",
+                bytes.len(),
+                xdsa::PUBLIC_KEY_SIZE,
+            ))
+        })?;
+        xdsa::PublicKey::from_bytes(&arr).map_err(|e| cbor::Error::DecodeFailed(e.to_string()))
+    }
+}
+
+impl ConfirmKey for xdsa::PublicKey {}
+
+impl sealed::ConfirmKeySealed for xhpke::PublicKey {
+    const ALGORITHM: i64 = cose::ALGORITHM_ID_XHPKE;
+
+    fn to_confirm_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+
+    fn from_confirm_bytes(bytes: &[u8]) -> Result<Self, cbor::Error> {
+        let arr: [u8; xhpke::PUBLIC_KEY_SIZE] = bytes.try_into().map_err(|_| {
+            cbor::Error::DecodeFailed(format!(
+                "cnf: unexpected key size {}, want {}",
+                bytes.len(),
+                xhpke::PUBLIC_KEY_SIZE,
+            ))
+        })?;
+        xhpke::PublicKey::from_bytes(&arr).map_err(|e| cbor::Error::DecodeFailed(e.to_string()))
+    }
+}
+
+impl ConfirmKey for xhpke::PublicKey {}
+
+/// Confirm binds a public key to the token via the cnf claim (key 8, RFC 8747).
+/// The COSE_Key wrapping is handled internally.
+#[derive(Clone, Debug)]
+pub struct Confirm<T: ConfirmKey> {
+    key: T,
+}
+
+impl<T: ConfirmKey> Confirm<T> {
+    /// Creates a Confirm value binding the given public key.
+    pub fn new(key: T) -> Self {
+        Self { key }
+    }
+
+    /// Returns a reference to the bound public key.
+    pub fn key(&self) -> &T {
+        &self.key
+    }
+}
+
+/// Internal: `{ 1: COSE_Key }` — the cnf claim value envelope.
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+struct CnfMap {
+    #[cbor(key = 1)]
+    cose_key: CoseKey,
+}
+
+/// Internal: `{ 1: kty, -2: x }` — a minimal COSE_Key. Parameter -2 carries
+/// the full public key bytes, following the OKP convention (RFC 9053 Section 7.2).
+#[derive(Clone, Debug, PartialEq, Eq, Cbor)]
+struct CoseKey {
+    #[cbor(key = 1)]
+    kty: i64,
+    #[cbor(key = -2)]
+    x: Vec<u8>,
+}
+
+impl<T: ConfirmKey> Encode for Confirm<T> {
+    fn encode_cbor_to(&self, buf: &mut Vec<u8>) -> Result<(), cbor::Error> {
+        let mut enc = MapEncodeBuffer::new(1);
+        <Self as MapEncode>::encode_map(self, &mut enc)?;
+        enc.finish_to(buf)
+    }
+}
+
+impl<T: ConfirmKey> Decode for Confirm<T> {
+    fn decode_cbor(data: &[u8]) -> Result<Self, cbor::Error> {
+        let mut dec = cbor::Decoder::new(data);
+        let result = Self::decode_cbor_notrail(&mut dec)?;
+        dec.finish()?;
+        Ok(result)
+    }
+
+    fn decode_cbor_notrail(dec: &mut cbor::Decoder<'_>) -> Result<Self, cbor::Error> {
+        let entries = cbor::decode_map_entries_slices_notrail(dec)?;
+        let mut remaining = cbor::MapEntries::new(entries);
+        let value = <Self as MapDecode>::decode_map(&mut remaining)?;
+        if !remaining.is_empty() {
+            let unknown: Vec<i64> = remaining.remaining_keys();
+            return Err(cbor::Error::DecodeFailed(format!(
+                "unknown CBOR map keys: {unknown:?}"
+            )));
+        }
+        Ok(value)
+    }
+}
+
+impl<T: ConfirmKey> MapEncode for Confirm<T> {
+    fn encode_map(&self, enc: &mut MapEncodeBuffer) -> Result<(), cbor::Error> {
+        let cnf = CnfMap {
+            cose_key: CoseKey {
+                kty: T::ALGORITHM,
+                x: self.key.to_confirm_bytes(),
+            },
+        };
+        enc.push(8, &cnf)
+    }
+}
+
+impl<T: ConfirmKey> MapDecode for Confirm<T> {
+    fn cbor_map_keys() -> &'static [i64] {
+        &[8]
+    }
+
+    fn decode_map<'a, E: MapEntryAccess<'a>>(entries: &mut E) -> Result<Self, cbor::Error> {
+        let raw = entries.take(8).ok_or(cbor::Error::DecodeFailed(
+            "missing required key 8 (cnf)".into(),
+        ))?;
+        let cnf = CnfMap::decode_cbor(raw)?;
+
+        // Verify the algorithm matches the expected key type
+        if cnf.cose_key.kty != T::ALGORITHM {
+            return Err(cbor::Error::DecodeFailed(format!(
+                "cnf: unexpected key type {}, want {}",
+                cnf.cose_key.kty,
+                T::ALGORITHM,
+            )));
+        }
+        let key = T::from_confirm_bytes(&cnf.cose_key.x)?;
+        Ok(Self { key })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies round-trip encoding of a Confirm<xdsa::PublicKey>.
+    #[test]
+    fn test_confirm_xdsa() {
+        let key = xdsa::SecretKey::generate().public_key();
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            cnf: Confirm<xdsa::PublicKey>,
+        }
+        let orig = Token {
+            cnf: Confirm::new(key.clone()),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.cnf.key().to_bytes(), key.to_bytes());
+    }
+
+    /// Verifies round-trip encoding of a Confirm<xhpke::PublicKey>.
+    #[test]
+    fn test_confirm_xhpke() {
+        let key = xhpke::SecretKey::generate().public_key();
+
+        #[derive(Debug, Cbor)]
+        struct Token {
+            #[cbor(embed)]
+            cnf: Confirm<xhpke::PublicKey>,
+        }
+        let orig = Token {
+            cnf: Confirm::new(key.clone()),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = Token::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.cnf.key().to_bytes(), key.to_bytes());
+    }
+
+    /// Verifies a struct embedding multiple claim types.
+    #[test]
+    fn test_composite_claims() {
+        let key = xdsa::SecretKey::generate().public_key();
+
+        #[derive(Debug, Cbor)]
+        struct DeviceCert {
+            #[cbor(embed)]
+            sub: Subject,
+            #[cbor(embed)]
+            exp: Expiration,
+            #[cbor(embed)]
+            nbf: NotBefore,
+            #[cbor(embed)]
+            cnf: Confirm<xdsa::PublicKey>,
+            #[cbor(key = 256)]
+            ueid: Vec<u8>,
+        }
+        let orig = DeviceCert {
+            sub: Subject {
+                sub: "device-abc-123".into(),
+            },
+            exp: Expiration { exp: 1000000 },
+            nbf: NotBefore { nbf: 100 },
+            cnf: Confirm::new(key.clone()),
+            ueid: b"SN-12345".to_vec(),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+        let got = DeviceCert::decode_cbor(&data).expect("decode");
+
+        assert_eq!(got.sub.sub, "device-abc-123");
+        assert_eq!(got.exp.exp, 1000000);
+        assert_eq!(got.nbf.nbf, 100);
+        assert_eq!(got.cnf.key().to_bytes(), key.to_bytes());
+        assert_eq!(got.ueid, b"SN-12345");
+    }
+
+    /// Tests that decoding a cnf with mismatched kty fails.
+    #[test]
+    fn test_confirm_wrong_key_type() {
+        let key = xdsa::SecretKey::generate().public_key();
+
+        #[derive(Debug, Cbor)]
+        struct XdsaToken {
+            #[cbor(embed)]
+            cnf: Confirm<xdsa::PublicKey>,
+        }
+        #[derive(Debug, Cbor)]
+        struct XhpkeToken {
+            #[cbor(embed)]
+            cnf: Confirm<xhpke::PublicKey>,
+        }
+        let orig = XdsaToken {
+            cnf: Confirm::new(key),
+        };
+        let data = cbor::encode(&orig).expect("encode");
+
+        // Decoding as xhpke should fail due to key type mismatch
+        let err = XhpkeToken::decode_cbor(&data).expect_err("should fail with wrong key type");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unexpected key type"),
+            "expected key type error, got: {msg}"
+        );
+    }
+}

--- a/src/cwt/mod.rs
+++ b/src/cwt/mod.rs
@@ -1,0 +1,440 @@
+// crypto-rs: cryptography primitives and wrappers
+// Copyright 2026 Dark Bio AG. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//! CBOR Web Tokens on top of COSE Sign1.
+//!
+//! <https://datatracker.ietf.org/doc/html/rfc8392>
+//!
+//! Tokens carry a set of claims encoded as a CBOR map. Standard claims are
+//! provided as embeddable single-field structs ([`claims::Issuer`],
+//! [`claims::Subject`], etc.) that can be composed into application-specific
+//! token types.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use darkbio_crypto::cbor::Cbor;
+//! use darkbio_crypto::cwt::{self, claims};
+//! use darkbio_crypto::xdsa;
+//!
+//! #[derive(Cbor)]
+//! struct DeviceCert {
+//!     #[cbor(embed)]
+//!     sub: claims::Subject,
+//!     #[cbor(embed)]
+//!     exp: claims::Expiration,
+//!     #[cbor(embed)]
+//!     nbf: claims::NotBefore,
+//!     #[cbor(embed)]
+//!     cnf: claims::Confirm<xdsa::PublicKey>,
+//!     #[cbor(key = 256)]
+//!     ueid: Vec<u8>,
+//! }
+//!
+//! let token = cwt::issue(&cert, &signer_key, "device-cert").unwrap();
+//! let verified: DeviceCert = cwt::verify(&token, &issuer_pub, "device-cert", Some(now)).unwrap();
+//! ```
+
+pub mod claims;
+
+use crate::cbor::{self, Decode, Encode, Raw};
+use crate::{cose, xdsa};
+
+/// Error is the failures that can occur during CWT operations.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum Error {
+    #[error("cbor: {0}")]
+    Cbor(#[from] cbor::Error),
+    #[error("cose: {0}")]
+    Cose(#[from] cose::Error),
+    #[error("missing nbf claim")]
+    MissingNbf,
+    #[error("token not yet valid: nbf {nbf} > now {now}")]
+    NotYetValid { nbf: u64, now: u64 },
+    #[error("token already expired: exp {exp} <= now {now}")]
+    AlreadyExpired { exp: u64, now: u64 },
+}
+
+/// issue signs a set of claims as a CWT using COSE Sign1.
+///
+/// The claims value must be a struct whose fields encode as a CBOR map
+/// (using `#[cbor(key = N)]` tags and/or embedded claim types).
+///
+/// Uses the current system time as the COSE signature timestamp.
+pub fn issue(
+    claims: &impl Encode,
+    signer: &xdsa::SecretKey,
+    domain: &str,
+) -> Result<Vec<u8>, Error> {
+    let claims_bytes = cbor::encode(claims)?;
+    Ok(cose::sign(
+        Raw(claims_bytes),
+        cbor::NULL,
+        signer,
+        domain.as_bytes(),
+    )?)
+}
+
+/// issue_at signs a set of claims as a CWT with an explicit COSE timestamp.
+///
+/// This is primarily useful for testing with deterministic timestamps.
+pub fn issue_at(
+    claims: &impl Encode,
+    signer: &xdsa::SecretKey,
+    domain: &str,
+    timestamp: i64,
+) -> Result<Vec<u8>, Error> {
+    let claims_bytes = cbor::encode(claims)?;
+    Ok(cose::sign_at(
+        Raw(claims_bytes),
+        cbor::NULL,
+        signer,
+        domain.as_bytes(),
+        timestamp,
+    )?)
+}
+
+/// verify verifies a CWT's COSE signature and temporal validity, then decodes
+/// the claims into T.
+///
+/// When `now` is `Some`, temporal claims are validated: nbf (key 5) must be
+/// present and `nbf <= now`, and if exp (key 4) is present then `now < exp`.
+/// When `now` is `None`, temporal validation is skipped entirely.
+pub fn verify<T: Decode>(
+    data: &[u8],
+    verifier: &xdsa::PublicKey,
+    domain: &str,
+    now: Option<u64>,
+) -> Result<T, Error> {
+    // Verify COSE signature (skip COSE drift check — CWT handles temporal validation)
+    let raw: Raw = cose::verify(data, &cbor::NULL, verifier, domain.as_bytes(), None)?;
+
+    // Extract and validate temporal claims if requested
+    if let Some(now) = now {
+        let (nbf, exp) = read_temporal_claims(&raw)?;
+        if now < nbf {
+            return Err(Error::NotYetValid { nbf, now });
+        }
+        if let Some(exp) = exp {
+            if now >= exp {
+                return Err(Error::AlreadyExpired { exp, now });
+            }
+        }
+    }
+    // Decode claims into T
+    Ok(cbor::decode(&raw.0)?)
+}
+
+/// signer extracts the signer's fingerprint from a CWT without verifying
+/// the signature. The returned data is unauthenticated.
+pub fn signer(data: &[u8]) -> Result<xdsa::Fingerprint, Error> {
+    Ok(cose::signer(data)?)
+}
+
+/// peek extracts and decodes claims from a CWT without verifying the signature.
+///
+/// **Warning**: This function does NOT verify the signature. The returned payload
+/// is unauthenticated and should not be trusted until verified with [`verify`].
+/// Use [`signer`] to extract the signer's fingerprint for key lookup. The single
+/// case for this method is self-signed key discovery.
+pub fn peek<T: Decode>(data: &[u8]) -> Result<T, Error> {
+    let raw: Raw = cose::peek(data)?;
+    Ok(cbor::decode(&raw.0)?)
+}
+
+/// Reads temporal claims (exp key 4, nbf key 5) from raw CBOR map bytes.
+/// Returns nbf (required) and exp (optional, None if absent).
+fn read_temporal_claims(raw: &[u8]) -> Result<(u64, Option<u64>), Error> {
+    let mut dec = cbor::Decoder::new(raw);
+    let n = dec.decode_map_header().map_err(cbor::Error::from)?;
+
+    let mut nbf: Option<u64> = None;
+    let mut exp: Option<u64> = None;
+
+    for _ in 0..n {
+        let key = dec.decode_int().map_err(cbor::Error::from)?;
+        match key {
+            4 => {
+                // exp
+                exp = Some(dec.decode_uint().map_err(cbor::Error::from)?);
+            }
+            5 => {
+                // nbf
+                nbf = Some(dec.decode_uint().map_err(cbor::Error::from)?);
+            }
+            _ => {
+                // Skip unknown claim value
+                Raw::decode_cbor_notrail(&mut dec).map_err(cbor::Error::from)?;
+            }
+        }
+    }
+    let nbf = nbf.ok_or(Error::MissingNbf)?;
+    Ok((nbf, exp))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cbor::Cbor;
+    use crate::cwt::claims;
+    use crate::cwt::claims::eat;
+
+    /// simpleCert is the minimal token type used by most tests.
+    #[derive(Debug, Cbor)]
+    struct SimpleCert {
+        #[cbor(embed)]
+        sub: claims::Subject,
+        #[cbor(embed)]
+        exp: Option<claims::Expiration>,
+        #[cbor(embed)]
+        nbf: claims::NotBefore,
+        #[cbor(embed)]
+        cnf: claims::Confirm<xdsa::PublicKey>,
+    }
+
+    /// deviceCert is a composite token type with EAT claims.
+    #[derive(Debug, Cbor)]
+    struct DeviceCert {
+        #[cbor(embed)]
+        sub: claims::Subject,
+        #[cbor(embed)]
+        exp: Option<claims::Expiration>,
+        #[cbor(embed)]
+        nbf: claims::NotBefore,
+        #[cbor(embed)]
+        cnf: claims::Confirm<xdsa::PublicKey>,
+        #[cbor(embed)]
+        ueid: eat::Ueid,
+    }
+
+    /// Token type without NotBefore, used for missing-nbf test.
+    #[derive(Debug, Cbor)]
+    struct NoNbfCert {
+        #[cbor(embed)]
+        sub: claims::Subject,
+        #[cbor(embed)]
+        cnf: claims::Confirm<xdsa::PublicKey>,
+    }
+
+    /// Token type without Expiration, used for no-expiration test.
+    #[derive(Debug, Cbor)]
+    struct NoExpCert {
+        #[cbor(embed)]
+        sub: claims::Subject,
+        #[cbor(embed)]
+        nbf: claims::NotBefore,
+        #[cbor(embed)]
+        cnf: claims::Confirm<xdsa::PublicKey>,
+    }
+
+    /// Tests the happy path: issue a token and verify it.
+    #[test]
+    fn test_issue_verify() {
+        let issuer = xdsa::SecretKey::generate();
+        let device = xdsa::SecretKey::generate();
+
+        let cert = DeviceCert {
+            sub: claims::Subject {
+                sub: "device-abc".into(),
+            },
+            exp: Some(claims::Expiration { exp: 2000000 }),
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(device.public_key()),
+            ueid: eat::Ueid {
+                ueid: b"SN-999".to_vec(),
+            },
+        };
+        let token = issue(&cert, &issuer, "test-domain").expect("issue");
+        let got: DeviceCert =
+            verify(&token, &issuer.public_key(), "test-domain", Some(1500000)).expect("verify");
+
+        assert_eq!(got.sub.sub, "device-abc");
+        assert_eq!(got.exp.unwrap().exp, 2000000);
+        assert_eq!(got.cnf.key().to_bytes(), device.public_key().to_bytes(),);
+        assert_eq!(got.ueid.ueid, b"SN-999");
+    }
+
+    /// Tests that now=None skips temporal validation.
+    #[test]
+    fn test_verify_skip_time() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: None,
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+        let got: SimpleCert =
+            verify(&token, &issuer.public_key(), "test", None).expect("verify with None time");
+
+        assert_eq!(got.sub.sub, "test");
+    }
+
+    /// Tests rejection when now < nbf.
+    #[test]
+    fn test_verify_not_yet_valid() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: None,
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+        let err = verify::<SimpleCert>(&token, &issuer.public_key(), "test", Some(500000))
+            .expect_err("should fail");
+
+        assert!(matches!(err, Error::NotYetValid { .. }));
+    }
+
+    /// Tests rejection when now > exp.
+    #[test]
+    fn test_verify_expired() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: Some(claims::Expiration { exp: 2000000 }),
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+        let err = verify::<SimpleCert>(&token, &issuer.public_key(), "test", Some(3000000))
+            .expect_err("should fail");
+
+        assert!(matches!(err, Error::AlreadyExpired { .. }));
+    }
+
+    /// Tests rejection when nbf is absent and time check is on.
+    #[test]
+    fn test_verify_missing_nbf() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = NoNbfCert {
+            sub: claims::Subject { sub: "test".into() },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+        let err = verify::<NoNbfCert>(&token, &issuer.public_key(), "test", Some(1000000))
+            .expect_err("should fail");
+
+        assert!(matches!(err, Error::MissingNbf));
+    }
+
+    /// Tests rejection with wrong verifier key.
+    #[test]
+    fn test_verify_wrong_key() {
+        let issuer = xdsa::SecretKey::generate();
+        let wrong = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: None,
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+
+        assert!(verify::<SimpleCert>(&token, &wrong.public_key(), "test", Some(1500000)).is_err());
+    }
+
+    /// Tests fingerprint extraction from a token.
+    #[test]
+    fn test_signer() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: None,
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+        let fp = signer(&token).expect("signer");
+
+        assert_eq!(fp, issuer.public_key().fingerprint());
+    }
+
+    /// Tests unauthenticated claims extraction.
+    #[test]
+    fn test_peek() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject {
+                sub: "peek-test".into(),
+            },
+            exp: None,
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+        let got: SimpleCert = peek(&token).expect("peek");
+
+        assert_eq!(got.sub.sub, "peek-test");
+    }
+
+    /// Tests rejection when the verification domain differs.
+    #[test]
+    fn test_verify_wrong_domain() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: None,
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "domain-a").expect("issue");
+
+        assert!(
+            verify::<SimpleCert>(&token, &issuer.public_key(), "domain-b", Some(1500000)).is_err()
+        );
+    }
+
+    /// Tests that now == nbf passes and now == exp fails per RFC 8392.
+    #[test]
+    fn test_verify_boundary_exact() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = SimpleCert {
+            sub: claims::Subject { sub: "test".into() },
+            exp: Some(claims::Expiration { exp: 2000000 }),
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+
+        // now == nbf should pass
+        verify::<SimpleCert>(&token, &issuer.public_key(), "test", Some(1000000))
+            .expect("now == nbf should pass");
+
+        // now == exp should fail
+        let err = verify::<SimpleCert>(&token, &issuer.public_key(), "test", Some(2000000))
+            .expect_err("now == exp should fail");
+        assert!(matches!(err, Error::AlreadyExpired { .. }));
+    }
+
+    /// Tests that a token without exp passes time validation.
+    #[test]
+    fn test_verify_no_expiration() {
+        let issuer = xdsa::SecretKey::generate();
+
+        let cert = NoExpCert {
+            sub: claims::Subject { sub: "test".into() },
+            nbf: claims::NotBefore { nbf: 1000000 },
+            cnf: claims::Confirm::new(xdsa::SecretKey::generate().public_key()),
+        };
+        let token = issue(&cert, &issuer, "test").expect("issue");
+
+        // Should pass even far in the future since there's no exp
+        verify::<NoExpCert>(&token, &issuer.public_key(), "test", Some(99999999))
+            .expect("no exp should pass");
+    }
+}

--- a/src/cwt/mod.rs
+++ b/src/cwt/mod.rs
@@ -120,7 +120,9 @@ pub fn verify<T: Decode>(
         if now < nbf {
             return Err(Error::NotYetValid { nbf, now });
         }
-        if let Some(exp) = exp && now >= exp {
+        if let Some(exp) = exp
+            && now >= exp
+        {
             return Err(Error::AlreadyExpired { exp, now });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub mod cbor;
 #[cfg(feature = "cose")]
 pub mod cose;
 
+#[cfg(feature = "cwt")]
+pub mod cwt;
+
 #[cfg(feature = "eddsa")]
 pub mod eddsa;
 


### PR DESCRIPTION
This PR is a quite lightweight CWT implementation on top of CBOR and COSE. It features most of the base CWT claims and also the simpler EAT ones. There was no attempt made to be fully thorough and some decisions are spec hostile (stricter).