### PR TITLE
cwt: fix domain from str to [u8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "darkbio-crypto"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "age-core",
  "argon2",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "darkbio-crypto-cbor-derive"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkbio-crypto"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Péter Szilágyi <peter@dark.bio>"]
 description = "Cryptography primitives and wrappers"
 repository = "https://github.com/dark-bio/crypto-rs"
@@ -72,7 +72,7 @@ base64 = { version = "0.22.1", optional = true }
 chacha20poly1305 = { version = "0.10.1", optional = true }
 chrono = { version = "0.4.41", optional = true }
 const-oid = { version = "0.9.6", optional = true }
-darkbio-crypto-cbor-derive = { version = "0.13.0", path = "src/cbor/derive", optional = true }
+darkbio-crypto-cbor-derive = { version = "0.14.0", path = "src/cbor/derive", optional = true }
 der = { version = "0.7.10", features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.2.0", features = ["pem", "rand_core"], optional = true }
 generic-array = { version = "0.14.7", optional = true }

--- a/src/cbor/derive/Cargo.toml
+++ b/src/cbor/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkbio-crypto-cbor-derive"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Péter Szilágyi <peter@dark.bio>"]
 description = "CBOR derive macros for darkbio-crypto"
 repository = "https://github.com/dark-bio/crypto-rs"


### PR DESCRIPTION
The CWT domain in the previous version ended up as `&str`, which is fine, but wonky. Fix it to `&[u8]`.