### PR TITLE
x509: reject certificates with unhandled critical extensions

### DIFF
--- a/src/x509/error.rs
+++ b/src/x509/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     InvalidPathLen { details: &'static str },
     #[error("invalid issuer: {details}")]
     InvalidIssuer { details: &'static str },
+    #[error("unhandled critical extension: {oid}")]
+    UnhandledCriticalExtension { oid: String },
     #[error(transparent)]
     Der(#[from] der::Error),
     #[error(transparent)]

--- a/src/x509/verify.rs
+++ b/src/x509/verify.rs
@@ -145,8 +145,15 @@ fn extract_cert(cert: &x509_parser::certificate::X509Certificate) -> Result<(Cer
             | ParsedExtension::BasicConstraints(_)
             | ParsedExtension::KeyUsage(_) => {}
             _ => {
+                // RFC 5280 §4.2: an application that cannot process a critical
+                // extension MUST reject the certificate. This verifier acts only
+                // on the four extensions matched above, so any other extension
+                // marked critical is unhandled and must be rejected.
+                if ext.critical {
+                    return Err(Error::UnhandledCriticalExtension { oid });
+                }
                 extensions.push(Extension {
-                    oid: ObjectIdentifier::new(ext.oid.to_id_string().as_str())?,
+                    oid: ObjectIdentifier::new(oid.as_str())?,
                     critical: ext.critical,
                     value: ext.value.to_vec(),
                 });
@@ -1084,6 +1091,49 @@ mod test {
         let der = cert.to_der().unwrap();
         let result = xdsa::verify_cert_der(&der, &issuer.public_key(), ValidityCheck::Now);
         assert!(result.is_err());
+    }
+
+    /// Verifies that a certificate carrying an unknown extension marked critical
+    /// is rejected (RFC 5280 §4.2), while the same extension marked non-critical
+    /// is accepted.
+    #[test]
+    fn test_verify_rejects_unknown_critical_extension() {
+        let subject = xdsa::SecretKey::generate();
+        let issuer = xdsa::SecretKey::generate();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        let custom_oid = ObjectIdentifier::new("1.3.6.1.4.1.62253.7.7").unwrap();
+
+        // Same template shape, toggling only the criticality of the unknown extension.
+        let make_template = |critical: bool| Certificate {
+            subject: Name::new().cn("Alice Identity"),
+            issuer: Name::new().cn("Root"),
+            not_before: now,
+            not_after: now + 3600,
+            role: Role::Leaf,
+            extensions: vec![Extension {
+                oid: custom_oid,
+                critical,
+                value: vec![0x05, 0x00], // DER NULL
+            }],
+            ..Default::default()
+        };
+
+        // Critical unknown extension -> rejected.
+        let critical_pem =
+            xdsa::issue_cert_pem(&subject.public_key(), &issuer, &make_template(true)).unwrap();
+        let result = xdsa::verify_cert_pem(&critical_pem, &issuer.public_key(), ValidityCheck::Now);
+        assert!(matches!(result, Err(Error::UnhandledCriticalExtension { .. })));
+
+        // Same extension, non-critical -> accepted.
+        let noncritical_pem =
+            xdsa::issue_cert_pem(&subject.public_key(), &issuer, &make_template(false)).unwrap();
+        let result =
+            xdsa::verify_cert_pem(&noncritical_pem, &issuer.public_key(), ValidityCheck::Now);
+        assert!(result.is_ok());
     }
 
     /// Verifies that a subjectPublicKey BIT STRING with non-zero unused bits is rejected.


### PR DESCRIPTION
## Summary

The X.509 verifier silently accepts certificates carrying **unrecognized critical extensions**, violating RFC 5280 §4.2 (CWE-295).

In `extract_cert()` ([src/x509/verify.rs](src/x509/verify.rs)) only four extensions are acted upon — `SubjectKeyIdentifier`, `AuthorityKeyIdentifier`, `BasicConstraints`, `KeyUsage`. Every other extension is pushed into a generic list with its `critical` bit copied but **never consulted** by any verification routine. As a result, restrictions a CA places via critical extensions are silently ignored:

- **Extended Key Usage** unenforced — a cert issued for e.g. `codeSigning` only is accepted for any purpose.
- **Name Constraints** unenforced — a deliberately constrained sub-CA can vouch for arbitrary subjects.
- **Policy Constraints / inhibitAnyPolicy** likewise ignored.

Because the gap is in the single-certificate path, it applies to both leaf and CA certificates and to both the xDSA (identity) and xHPKE (encryption) certificate profiles, which both route through `x509::verify_cert` → `extract_cert`.

> RFC 5280 §4.2: If a certificate contains a critical extension that a certificate-using application cannot process, then the application MUST reject the certificate.

## Fix

Reject any extension that lands in the catch-all arm when its `critical` bit is set, via a new `Error::UnhandledCriticalExtension`. Non-critical unknown extensions remain accepted and stored as before, preserving existing behaviour for custom extensions.

## Test

Adds `test_verify_rejects_unknown_critical_extension`, asserting that an unknown extension marked critical is rejected and that the same extension marked non-critical is accepted.

## Notes

The accompanying audit also flagged a separate HIGH issue — `pathLenConstraint` is not propagated down the chain in `enforce_issuer_chaining()`. That requires threading RFC 5280 §6.1 `max_path_length` bookkeeping through the verified-chain state and is left for a follow-up PR.