### PR TITLE
all: zero out sensitive material wherever possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ eddsa = [
     "pem",
     "dep:der",
     "dep:ed25519-dalek",
+    "ed25519-dalek/zeroize",
     "dep:pkcs8",
     "dep:serde",
     "dep:sha2",
     "dep:signature",
     "dep:spki",
+    "dep:zeroize",
 ]
 hkdf = ["dep:hkdf", "dep:sha2"]
 mldsa = [
@@ -47,7 +49,7 @@ mldsa = [
 ]
 pem = ["dep:base64"]
 rand = []
-rsa = ["pem", "dep:rsa", "dep:serde"]
+rsa = ["pem", "dep:rsa", "dep:serde", "dep:zeroize"]
 stream = ["dep:age-core", "dep:chacha20poly1305", "dep:pin-project", "dep:zeroize"]
 xdsa = ["pem", "eddsa", "mldsa"]
 xhpke = [
@@ -62,6 +64,7 @@ xhpke = [
     "dep:spki",
     "dep:subtle",
     "dep:x-wing",
+    "dep:zeroize",
 ]
 
 [dependencies]

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -23,6 +23,7 @@ use spki::der::AnyRef;
 use spki::der::asn1::BitStringRef;
 use spki::{AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfo};
 use std::error::Error;
+use zeroize::Zeroizing;
 
 /// OID is the ASN.1 object identifier for Ed25519.
 pub const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
@@ -56,8 +57,8 @@ impl SecretKey {
 
     /// from_bytes converts a 32-byte array into a private key.
     pub fn from_bytes(bin: &[u8; SECRET_KEY_SIZE]) -> Self {
-        let key = ed25519_dalek::SecretKey::from(*bin);
-        let sig = ed25519_dalek::SigningKey::from(&key);
+        let key = Zeroizing::new(ed25519_dalek::SecretKey::from(*bin));
+        let sig = ed25519_dalek::SigningKey::from(&*key);
         Self { inner: sig }
     }
 
@@ -82,19 +83,19 @@ impl SecretKey {
         if kind != "PRIVATE KEY" {
             return Err(format!("invalid PEM tag {}", kind).into());
         }
-        Self::from_der(&data)
+        Self::from_der(&Zeroizing::new(data))
     }
 
     /// to_bytes converts a private key into a 32-byte array.
-    pub fn to_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
-        self.inner.to_bytes()
+    pub fn to_bytes(&self) -> Zeroizing<[u8; SECRET_KEY_SIZE]> {
+        Zeroizing::new(self.inner.to_bytes())
     }
 
     /// to_der serializes a private key into a DER buffer.
-    pub fn to_der(&self) -> Vec<u8> {
+    pub fn to_der(&self) -> Zeroizing<Vec<u8>> {
         // The private key field contains an OCTET STRING wrapping the seed
         let seed = OctetString::new(self.inner.to_bytes()).unwrap();
-        let inner = seed.to_der().unwrap();
+        let inner = Zeroizing::new(seed.to_der().unwrap());
 
         let alg = pkcs8::AlgorithmIdentifierRef {
             oid: OID,
@@ -105,12 +106,12 @@ impl SecretKey {
             private_key: &inner,
             public_key: None,
         };
-        info.to_der().unwrap()
+        Zeroizing::new(info.to_der().unwrap())
     }
 
     /// to_pem serializes a private key into a PEM string.
-    pub fn to_pem(&self) -> String {
-        pem::encode("PRIVATE KEY", &self.to_der())
+    pub fn to_pem(&self) -> Zeroizing<String> {
+        Zeroizing::new(pem::encode("PRIVATE KEY", &self.to_der()))
     }
 
     /// public_key retrieves the public counterpart of the secret key.

--- a/src/mldsa/mod.rs
+++ b/src/mldsa/mod.rs
@@ -21,7 +21,7 @@ use spki::der::asn1::BitStringRef;
 use spki::{AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfo};
 use std::error::Error;
 use subtle::ConstantTimeEq;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::pem;
 
@@ -41,7 +41,7 @@ pub const SIGNATURE_SIZE: usize = 3309;
 pub const FINGERPRINT_SIZE: usize = 32;
 
 /// ML-DSA-65 private key inner structure.
-#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[derive(Clone, Eq, PartialEq, Sequence)]
 struct MlDsa65PrivateKeyInner {
     seed: OctetString,
     expanded: OctetString,
@@ -100,7 +100,7 @@ impl SecretKey {
             .as_bytes()
             .try_into()
             .map_err(|_| "seed not 32 bytes")?;
-        let expanded: [u8; 4032] = inner_key
+        let mut expanded: [u8; 4032] = inner_key
             .expanded
             .as_bytes()
             .try_into()
@@ -110,8 +110,11 @@ impl SecretKey {
         let inner = ml_dsa::SigningKey::<MlDsa65>::from_seed(&seed);
 
         #[allow(deprecated)] // to_expanded is wasteful, but that's the DER spec
-        let enc = inner.expanded_key().to_expanded();
-        if enc.as_slice().ct_ne(&expanded).into() {
+        let mut enc = inner.expanded_key().to_expanded();
+        let mismatch: bool = enc.as_slice().ct_ne(&expanded).into();
+        expanded.zeroize();
+        enc.as_mut_slice().zeroize();
+        if mismatch {
             return Err("expanded key does not match seed".into());
         }
         Ok(Self { inner, seed })
@@ -125,26 +128,27 @@ impl SecretKey {
             return Err(format!("invalid PEM tag {}", kind).into());
         }
         // Parse the DER content
-        Self::from_der(&data)
+        Self::from_der(&Zeroizing::new(data))
     }
 
     /// to_bytes returns the 32-byte seed of the private key.
-    pub fn to_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
-        let mut out = [0u8; 32];
+    pub fn to_bytes(&self) -> Zeroizing<[u8; SECRET_KEY_SIZE]> {
+        let mut out = Zeroizing::new([0u8; 32]);
         out.copy_from_slice(self.seed.as_slice());
         out
     }
 
     /// to_der serializes a private key into a DER buffer.
-    pub fn to_der(&self) -> Vec<u8> {
+    pub fn to_der(&self) -> Zeroizing<Vec<u8>> {
         #[allow(deprecated)] // to_expanded is wasteful, but that's the DER spec
-        let enc = self.inner.expanded_key().to_expanded();
+        let mut enc = self.inner.expanded_key().to_expanded();
 
         let inner_key = MlDsa65PrivateKeyInner {
             seed: OctetString::new(self.seed.as_slice()).unwrap(),
             expanded: OctetString::new(enc.as_slice()).unwrap(),
         };
-        let inner = inner_key.to_der().unwrap();
+        enc.as_mut_slice().zeroize();
+        let inner = Zeroizing::new(inner_key.to_der().unwrap());
 
         let alg = pkcs8::AlgorithmIdentifierRef {
             oid: OID,
@@ -155,12 +159,12 @@ impl SecretKey {
             private_key: &inner,
             public_key: None,
         };
-        info.to_der().unwrap()
+        Zeroizing::new(info.to_der().unwrap())
     }
 
     /// to_pem serializes a private key into a PEM string.
-    pub fn to_pem(&self) -> String {
-        pem::encode("PRIVATE KEY", &self.to_der())
+    pub fn to_pem(&self) -> Zeroizing<String> {
+        Zeroizing::new(pem::encode("PRIVATE KEY", &self.to_der()))
     }
 
     /// public_key retrieves the public counterpart of the secret key.

--- a/src/rsa/mod.rs
+++ b/src/rsa/mod.rs
@@ -19,6 +19,7 @@ use rsa::signature::{Keypair, SignatureEncoding, Signer, Verifier};
 use rsa::traits::{PrivateKeyParts, PublicKeyParts};
 use rsa::{BigUint, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use zeroize::Zeroizing;
 
 /// Size of the raw secret key in bytes.
 /// Format: p (128 bytes) || q (128 bytes) || d (256 bytes) || e (8 bytes)
@@ -112,26 +113,26 @@ impl SecretKey {
             return Err(format!("invalid PEM tag {}", kind).into());
         }
         // Parse the DER content
-        Self::from_der(&data)
+        Self::from_der(&Zeroizing::new(data))
     }
 
     /// to_bytes serializes a private key into a 520-byte array.
     ///
     /// Format: p (128 bytes) || q (128 bytes) || d (256 bytes) || e (8 bytes),
     /// all in big-endian.
-    pub fn to_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
+    pub fn to_bytes(&self) -> Zeroizing<[u8; SECRET_KEY_SIZE]> {
         let key: &RsaPrivateKey = self.inner.as_ref();
         let primes = key.primes();
 
-        let mut out = [0u8; 520];
+        let mut out = Zeroizing::new([0u8; 520]);
 
-        let p_bytes = primes[0].to_bytes_be();
+        let p_bytes = Zeroizing::new(primes[0].to_bytes_be());
         out[128 - p_bytes.len()..128].copy_from_slice(&p_bytes);
 
-        let q_bytes = primes[1].to_bytes_be();
+        let q_bytes = Zeroizing::new(primes[1].to_bytes_be());
         out[256 - q_bytes.len()..256].copy_from_slice(&q_bytes);
 
-        let d_bytes = key.d().to_bytes_be();
+        let d_bytes = Zeroizing::new(key.d().to_bytes_be());
         out[512 - d_bytes.len()..512].copy_from_slice(&d_bytes);
 
         let e_bytes = key.e().to_bytes_be();
@@ -141,16 +142,18 @@ impl SecretKey {
     }
 
     /// to_der serializes a private key into a DER buffer.
-    pub fn to_der(&self) -> Vec<u8> {
-        rsa::pkcs1v15::SigningKey::<Sha256>::to_pkcs8_der(&self.inner)
-            .unwrap()
-            .as_bytes()
-            .to_vec()
+    pub fn to_der(&self) -> Zeroizing<Vec<u8>> {
+        Zeroizing::new(
+            rsa::pkcs1v15::SigningKey::<Sha256>::to_pkcs8_der(&self.inner)
+                .unwrap()
+                .as_bytes()
+                .to_vec(),
+        )
     }
 
     /// to_pem serializes a private key into a PEM string.
-    pub fn to_pem(&self) -> String {
-        pem::encode("PRIVATE KEY", &self.to_der())
+    pub fn to_pem(&self) -> Zeroizing<String> {
+        Zeroizing::new(pem::encode("PRIVATE KEY", &self.to_der()))
     }
 
     /// public_key retrieves the public counterpart of the secret key.

--- a/src/xdsa/mod.rs
+++ b/src/xdsa/mod.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use sha2::Digest;
 use spki::{AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfo};
 use std::error::Error;
+use zeroize::Zeroizing;
 
 /// Prefix is the byte encoding of "CompositeAlgorithmSignatures2025" per the
 /// IETF composite signature spec.
@@ -75,8 +76,8 @@ impl SecretKey {
 
     /// from_bytes creates a private key from a 64-byte seed.
     pub fn from_bytes(seed: &[u8; SECRET_KEY_SIZE]) -> Self {
-        let ml_seed: [u8; 32] = seed[..32].try_into().unwrap();
-        let ed_seed: [u8; 32] = seed[32..].try_into().unwrap();
+        let ml_seed: Zeroizing<[u8; 32]> = Zeroizing::new(seed[..32].try_into().unwrap());
+        let ed_seed: Zeroizing<[u8; 32]> = Zeroizing::new(seed[32..].try_into().unwrap());
 
         Self {
             ml_key: mldsa::SecretKey::from_bytes(&ml_seed),
@@ -98,10 +99,11 @@ impl SecretKey {
             return Err("not a composite ML-DSA-65-Ed25519-SHA512 private key".into());
         }
         // Private key is ML-DSA seed (32) || Ed25519 seed (32) = 64 bytes
-        let seed: [u8; 64] = info
-            .private_key
-            .try_into()
-            .map_err(|_| "composite private key must be 64 bytes")?;
+        let seed: Zeroizing<[u8; 64]> = Zeroizing::new(
+            info.private_key
+                .try_into()
+                .map_err(|_| "composite private key must be 64 bytes")?,
+        );
 
         Ok(Self::from_bytes(&seed))
     }
@@ -114,19 +116,19 @@ impl SecretKey {
             return Err(format!("invalid PEM tag {}", kind).into());
         }
         // Parse the DER content
-        Self::from_der(&data)
+        Self::from_der(&Zeroizing::new(data))
     }
 
     /// to_bytes converts a secret key into a 64-byte array.
-    pub fn to_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
-        let mut out = [0u8; 64];
-        out[..32].copy_from_slice(&self.ml_key.to_bytes());
-        out[32..].copy_from_slice(&self.ed_key.to_bytes());
+    pub fn to_bytes(&self) -> Zeroizing<[u8; SECRET_KEY_SIZE]> {
+        let mut out = Zeroizing::new([0u8; 64]);
+        out[..32].copy_from_slice(self.ml_key.to_bytes().as_slice());
+        out[32..].copy_from_slice(self.ed_key.to_bytes().as_slice());
         out
     }
 
     /// to_der serializes a private key into a DER buffer.
-    pub fn to_der(&self) -> Vec<u8> {
+    pub fn to_der(&self) -> Zeroizing<Vec<u8>> {
         // Create the MLDSA65-Ed25519-SHA512 algorithm identifier; parameters
         // MUST be absent
         let alg = pkcs8::AlgorithmIdentifierRef {
@@ -138,15 +140,15 @@ impl SecretKey {
 
         let info = pkcs8::PrivateKeyInfo {
             algorithm: alg,
-            private_key: &key_bytes,
+            private_key: key_bytes.as_slice(),
             public_key: None,
         };
-        info.to_der().unwrap()
+        Zeroizing::new(info.to_der().unwrap())
     }
 
     /// to_pem serializes a private key into a PEM string.
-    pub fn to_pem(&self) -> String {
-        pem::encode("PRIVATE KEY", &self.to_der())
+    pub fn to_pem(&self) -> Zeroizing<String> {
+        Zeroizing::new(pem::encode("PRIVATE KEY", &self.to_der()))
     }
 
     /// public_key retrieves the public counterpart of the secret key.
@@ -750,7 +752,7 @@ f6e178bcc044204110444ea2b7e80548769ae5010c22707493adb0baf55f\
 
         // Re-encoding to DER should match the test vector
         let encoded_der = seckey_from_seed.to_der();
-        assert_eq!(encoded_der, pkcs8_bytes);
+        assert_eq!(*encoded_der, pkcs8_bytes);
 
         // Round-trip: decode and re-encode
         let roundtrip = SecretKey::from_der(&encoded_der).unwrap();

--- a/src/xhpke/mod.rs
+++ b/src/xhpke/mod.rs
@@ -26,6 +26,7 @@ use spki::der::asn1::BitStringRef;
 use spki::der::{AnyRef, Decode, Encode};
 use spki::{AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfo};
 use std::error::Error;
+use zeroize::Zeroizing;
 
 /// OID is the ASN.1 object identifier for X-Wing.
 pub const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.62253.25722");
@@ -96,7 +97,7 @@ impl SecretKey {
         if info.algorithm.oid != OID {
             return Err("not an X-Wing private key".into());
         }
-        let bytes: [u8; 32] = info.private_key.try_into()?;
+        let bytes: Zeroizing<[u8; 32]> = Zeroizing::new(info.private_key.try_into()?);
         Ok(SecretKey::from_bytes(&bytes))
     }
 
@@ -108,17 +109,17 @@ impl SecretKey {
             return Err(format!("invalid PEM tag {}", kind).into());
         }
         // Parse the DER content
-        Self::from_der(&data)
+        Self::from_der(&Zeroizing::new(data))
     }
 
     /// to_bytes converts a private key into a 32-byte seed.
-    pub fn to_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
-        self.inner.to_bytes().into()
+    pub fn to_bytes(&self) -> Zeroizing<[u8; SECRET_KEY_SIZE]> {
+        Zeroizing::new(self.inner.to_bytes().into())
     }
 
     /// to_der serializes a private key into a DER buffer.
-    pub fn to_der(&self) -> Vec<u8> {
-        let bytes = self.inner.to_bytes();
+    pub fn to_der(&self) -> Zeroizing<Vec<u8>> {
+        let bytes = Zeroizing::new(<[u8; SECRET_KEY_SIZE]>::from(self.inner.to_bytes()));
 
         // Create the X-Wing algorithm identifier; parameters MUST be absent
         let alg = pkcs8::AlgorithmIdentifierRef {
@@ -128,15 +129,15 @@ impl SecretKey {
         // Per RFC, privateKey contains the raw 32-byte seed directly
         let info = PrivateKeyInfo {
             algorithm: alg,
-            private_key: &bytes,
+            private_key: bytes.as_slice(),
             public_key: None,
         };
-        info.to_der().unwrap()
+        Zeroizing::new(info.to_der().unwrap())
     }
 
     /// to_pem serializes a private key into a PEM string.
-    pub fn to_pem(&self) -> String {
-        pem::encode("PRIVATE KEY", &self.to_der())
+    pub fn to_pem(&self) -> Zeroizing<String> {
+        Zeroizing::new(pem::encode("PRIVATE KEY", &self.to_der()))
     }
 
     /// public_key retrieves the public counterpart of the secret key.


### PR DESCRIPTION
This PR forces users of this library into Zeroized types and also tries to zero out internal buffers too. Not ideal, we should really be using restricted memory areas altogether like OpenSSL does, but that's for a future hardening.